### PR TITLE
fix(semver): Make documentation suggest installing ^1 instead of latest.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,11 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
+      # In your code, add this:
+      # - run:
+      #    name: install-and-run-audit-ci
+      #    command: 'sudo npm i -g audit-ci@^1 && audit-ci -m'
+
       - run:
           name: npm-install
           command: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 node_js:
   - "8"
 
-# For your packages, include the following:
+# In your code, add this:
 # before_install:
-#   - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npm i -g audit-ci@latest && audit-ci -m; fi
+#   - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npm i -g audit-ci@^1 && audit-ci -m; fi
 
 install:
   - npm ci

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ For `Travis-CI` using PR builds (*recommended*):
 
 ```yml
 before_install:
-  - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npm i -g audit-ci@latest && audit-ci -m; fi
+  - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npm i -g audit-ci@^1 && audit-ci -m; fi
 ```
 
 For `Travis-CI` not using PR builds (*not recommended*):
 
 ```yml
 before_install:
-  - npm i -g audit-ci@latest && audit-ci -m
+  - npm i -g audit-ci@^1 && audit-ci -m
 ```
 
 
@@ -34,12 +34,12 @@ For `CircleCI`:
   - checkout
   - run:
       name: update-npm 
-      command: 'sudo npm i -g npm@latest'
+      command: 'sudo npm i -g npm@^1'
   - restore_cache:
       key: dependency-cache-{{ checksum "package.json" }}
   - run:
       name: install-and-run-audit-ci
-      command: 'sudo npm i -g audit-ci@latest && audit-ci -m'
+      command: 'sudo npm i -g audit-ci@^1 && audit-ci -m'
   - run:
       name: install-npm
       command: npm i
@@ -60,22 +60,22 @@ For `CircleCI`:
 
 ### Prevents build on moderate, high, or critical vulnerabilities; ignores low
 ```sh
-npm i -g audit-ci@latest && audit-ci -m
+npm i -g audit-ci@^1 && audit-ci -m
 ```
 
 ### Prevents build on any vulnerability except lodash (low) and base64url (moderate)
 ```sh
-npm i -g audit-ci@latest && audit-ci -l -w lodash base64url
+npm i -g audit-ci@^1 && audit-ci -l -w lodash base64url
 ```
 
 ### Prevents build with critical vulnerabilities using aliases without showing the report
 ```sh
-npm i -g audit-ci@latest && audit-ci --critical --report false
+npm i -g audit-ci@^1 && audit-ci --critical --report false
 ```
 
 ### Continues build regardless of vulnerabilities, but show the report
 ```sh
-npm i -g audit-ci@latest && audit-ci
+npm i -g audit-ci@^1 && audit-ci
 ```
 
 ## Q&A


### PR DESCRIPTION
This is to ensure that breaking changes in the future are not automatically applied with @latest.

Signed-off-by: Quinn Turner <quinn.turner@ibm.com>