### PR TITLE
feat(travis-cache): Include npm cache in Travis build to speed installs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ node_js:
 install:
   - npm ci
 
+# Keep the npm cache around to speed up installs
+cache:
+  directories:
+  - "$HOME/.npm"
+
 script:
   - npm run build
   # ensure no security vulnerabilities in our packages


### PR DESCRIPTION
Signed-off-by: Quinn Turner <quinn.turner@ibm.com>