### PR TITLE
chore: Change Quinn's IBM email to UWaterloo email

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,5 @@
 # MAINTAINERS
 
-Quinn Turner - quinn.turner@ibm.com
+Quinn Turner - quinn.turner@edu.uwaterloo.ca
 
 Andy Patterson - andypatt@ca.ibm.com


### PR DESCRIPTION
As I have completed my term at IBM, I am available for contact at my UWaterloo email address. I intend to continue maintaining this package.

For IBM-specific inquiries, contact Andy.