### PR TITLE
chore(node6): Added Node 6 to Travis-CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ node_js:
   - '8'
   - '10'
 
+# Even though we support Node 6, we still want to use NPM 6
 install:
+  - npmv=$(echo $(npm -v) | head -c 1); if [ "$npmv" -lt "6" ]; then npm i -g npm; fi
   - npm ci
 
 # In your code, add this (after installing with `npm install --save-dev audit-ci`):

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '6'
   - '8'
   - '10'
 


### PR DESCRIPTION
As discussed in https://github.com/IBM/audit-ci/issues/20, since `npm audit` is supported in Node 6, it is reasonable to support here. To ensure it is supported properly, we must add the Travis-CI build for Node 6.

This was possible due to work on https://github.com/IBM/audit-ci/pull/21

Signed-off-by: Quinn Turner <quinn.turner@edu.uwaterloo.ca>