### PR TITLE
chore(eslint): Remove deprecated valid-jsdoc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,6 @@
   "plugins": ["prettier"],
   "rules": {
     "no-console": "off",
-    "prettier/prettier": "error",
-    "valid-jsdoc": "error"
+    "prettier/prettier": "error"
   }
 }


### PR DESCRIPTION
There is no need to substitute JSDoc validation since the JSDocs are for internal use only.

Addresses: https://github.com/IBM/audit-ci/issues/24