### PR TITLE
fix: remove unnecessary dependency npm-audit-report

### DIFF
--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -5,74 +5,66 @@
  */
 /* eslint-disable max-len */
 const childProcess = require('child_process');
-const reporter = require('npm-audit-report');
 
 function reportAudit(npmAudit, config) {
-  return reporter(npmAudit, { reporter: 'json' }).then(reportResult => {
-    if (reportResult.exitCode) {
-      const err = 'npm-audit-report failed.';
-      return Promise.reject(new Error(err));
+  const { whitelist } = config;
+  if (whitelist.length) {
+    console.log(
+      '\x1b[36m%s\x1b[0m',
+      'Modules to whitelist: '.concat(whitelist.join(', '), '.')
+    );
+  }
+
+  if (config.report) {
+    console.log('\x1b[36m%s\x1b[0m', 'NPM audit report JSON:');
+    console.log(JSON.stringify(npmAudit, null, 2));
+  }
+
+  const { vulnerabilities } = npmAudit.metadata;
+  const failedLevels = [];
+  const whitelistedFound = [];
+  let failIfFindVulnerability = false;
+  ['low', 'moderate', 'high', 'critical'].forEach(level => {
+    if (config[level]) {
+      failIfFindVulnerability = true;
     }
 
-    const { whitelist } = config;
-    if (whitelist.length) {
-      console.log(
-        '\x1b[36m%s\x1b[0m',
-        'Modules to whitelist: '.concat(whitelist.join(', '), '.')
-      );
-    }
-
-    if (config.report) {
-      console.log('\x1b[36m%s\x1b[0m', 'NPM audit report JSON:');
-      console.log(reportResult.report);
-    }
-
-    const report = JSON.parse(reportResult.report);
-    const { vulnerabilities } = report.metadata;
-    const failedLevels = [];
-    const whitelistedFound = [];
-    let failIfFindVulnerability = false;
-    ['low', 'moderate', 'high', 'critical'].forEach(level => {
-      if (config[level]) {
-        failIfFindVulnerability = true;
+    if (vulnerabilities[level] > 0 && failIfFindVulnerability) {
+      if (whitelist.length) {
+        const advisories = Object.values(npmAudit.advisories);
+        advisories.forEach(advisory => {
+          if (
+            advisory.severity === level &&
+            whitelist.some(m => m === advisory.module_name)
+          ) {
+            whitelistedFound.push(advisory.module_name);
+          } else {
+            failedLevels.push(level);
+          }
+        });
+      } else {
+        failedLevels.push(level);
       }
-
-      if (vulnerabilities[level] > 0 && failIfFindVulnerability) {
-        if (whitelist.length) {
-          const advisories = Object.values(report.advisories);
-          advisories.forEach(advisory => {
-            if (
-              advisory.severity === level &&
-              whitelist.some(m => m === advisory.module_name)
-            ) {
-              whitelistedFound.push(advisory.module_name);
-            } else {
-              failedLevels.push(level);
-            }
-          });
-        } else {
-          failedLevels.push(level);
-        }
-      }
-    });
-
-    if (whitelistedFound.length) {
-      const msg = 'Vulnerable whitelisted modules found: '.concat(
-        whitelistedFound.join(', '),
-        '.'
-      );
-      console.warn('\x1b[33m%s\x1b[0m', msg);
     }
-
-    if (failedLevels.length) {
-      const err = 'Failed security audit due to '.concat(
-        failedLevels.join(', '),
-        ' vulnerabilities.'
-      );
-      return Promise.reject(new Error(err));
-    }
-    return report;
   });
+
+  if (whitelistedFound.length) {
+    const msg = 'Vulnerable whitelisted modules found: '.concat(
+      whitelistedFound.join(', '),
+      '.'
+    );
+    console.warn('\x1b[33m%s\x1b[0m', msg);
+  }
+
+  if (failedLevels.length) {
+    const err = 'Failed security audit due to '.concat(
+      failedLevels.join(', '),
+      ' vulnerabilities.'
+    );
+    throw new Error(err);
+  } else {
+    return npmAudit;
+  }
 }
 
 function runNpmAudit(callback) {
@@ -105,9 +97,12 @@ function audit(config) {
         reject(err);
         return;
       }
-      reportAudit(result, config)
-        .then(resolve)
-        .catch(reject);
+      try {
+        const report = reportAudit(result, config);
+        resolve(report);
+      } catch (error) {
+        reject(error);
+      }
     });
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,16 +180,6 @@
         "restore-cursor": "^2.0.0"
       }
     },
-    "cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
-      "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
-      }
-    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -226,22 +216,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-      "optional": true
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -1344,15 +1323,6 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
-    "npm-audit-report": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.1.tgz",
-      "integrity": "sha512-SjTF8ZP4rOu3JiFrTMi4M1CmVo2tni2sP4TzhyCMHwnMGf6XkdGLZKt9cdZ12esKf0mbQqFyU9LtY0SoeahL7g==",
-      "requires": {
-        "cli-table3": "^0.5.0",
-        "console-control-strings": "^1.1.0"
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -1369,7 +1339,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-keys": {
       "version": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "cross-spawn": "6.0.5",
-    "npm-audit-report": "1.3.1",
     "semver": "5.6.0",
     "yargs": "12.0.2"
   },


### PR DESCRIPTION
- Removes the Promise from `reportAudit` (which made the entire function reduce in indentation, creating a large diff)
- Instead of resolve/reject, return/throw Error and catch it in `runNpmAudit`