### PR TITLE
chore(npm-auditor): Make internal auditor API more consistent

### DIFF
--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -7,7 +7,7 @@
 const childProcess = require('child_process');
 
 function reportAudit(npmAudit, config) {
-  const { whitelist } = config;
+  const { levels, whitelist } = config;
   if (whitelist.length) {
     console.log(
       '\x1b[36m%s\x1b[0m',
@@ -20,47 +20,39 @@ function reportAudit(npmAudit, config) {
     console.log(JSON.stringify(npmAudit, null, 2));
   }
 
-  const { vulnerabilities } = npmAudit.metadata;
-  const failedLevels = [];
+  const failedLevels = {
+    low: false,
+    moderate: false,
+    high: false,
+    critical: false,
+  };
   const whitelistedFound = [];
-  let failIfFindVulnerability = false;
-  ['low', 'moderate', 'high', 'critical'].forEach(level => {
-    if (config[level]) {
-      failIfFindVulnerability = true;
-    }
 
-    if (vulnerabilities[level] > 0 && failIfFindVulnerability) {
-      if (whitelist.length) {
-        const advisories = Object.values(npmAudit.advisories);
-        advisories.forEach(advisory => {
-          if (
-            advisory.severity === level &&
-            whitelist.some(m => m === advisory.module_name)
-          ) {
-            whitelistedFound.push(advisory.module_name);
-          } else {
-            failedLevels.push(level);
-          }
-        });
+  const advisories = Object.values(npmAudit.advisories);
+  advisories.forEach(advisory => {
+    const { module_name: moduleName, severity } = advisory;
+    if (levels[severity]) {
+      if (whitelist.some(m => m === moduleName)) {
+        whitelistedFound.push(moduleName);
       } else {
-        failedLevels.push(level);
+        failedLevels[severity] = true;
       }
     }
   });
 
   if (whitelistedFound.length) {
-    const msg = 'Vulnerable whitelisted modules found: '.concat(
-      whitelistedFound.join(', '),
-      '.'
-    );
+    const found = whitelistedFound.join(', ');
+    const msg = `Vulnerable whitelisted modules found: ${found}.`;
     console.warn('\x1b[33m%s\x1b[0m', msg);
   }
 
-  if (failedLevels.length) {
-    const err = 'Failed security audit due to '.concat(
-      failedLevels.join(', '),
-      ' vulnerabilities.'
-    );
+  // If any of the levels have been failed
+  if (Object.values(failedLevels).some(val => val)) {
+    // Get the levels that have failed by filtering the keys with true values
+    const failedLevelsFound = Object.keys(failedLevels)
+      .filter(l => failedLevels[l])
+      .join(', ');
+    const err = `Failed security audit due to ${failedLevelsFound} vulnerabilities.`;
     throw new Error(err);
   } else {
     return npmAudit;

--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -28,17 +28,18 @@ function reportAudit(npmAudit, config) {
   };
   const whitelistedFound = [];
 
-  const advisories = Object.values(npmAudit.advisories);
-  advisories.forEach(advisory => {
-    const { module_name: moduleName, severity } = advisory;
-    if (levels[severity]) {
+  Object.keys(npmAudit.advisories)
+    // Get the advisories values (Object.values not supported in Node 6)
+    .map(k => npmAudit.advisories[k])
+    // Remove advisories that have a level that doesn't fail the build
+    .filter(({ severity }) => levels[severity])
+    .forEach(({ module_name: moduleName, severity }) => {
       if (whitelist.some(m => m === moduleName)) {
         whitelistedFound.push(moduleName);
       } else {
         failedLevels[severity] = true;
       }
-    }
-  });
+    });
 
   if (whitelistedFound.length) {
     const found = whitelistedFound.join(', ');
@@ -46,17 +47,17 @@ function reportAudit(npmAudit, config) {
     console.warn('\x1b[33m%s\x1b[0m', msg);
   }
 
+  // Get the levels that have failed by filtering the keys with true values
+  const failedLevelsFound = Object.keys(failedLevels)
+    .filter(l => failedLevels[l])
+    .join(', ');
   // If any of the levels have been failed
-  if (Object.values(failedLevels).some(val => val)) {
+  if (failedLevelsFound) {
     // Get the levels that have failed by filtering the keys with true values
-    const failedLevelsFound = Object.keys(failedLevels)
-      .filter(l => failedLevels[l])
-      .join(', ');
     const err = `Failed security audit due to ${failedLevelsFound} vulnerabilities.`;
     throw new Error(err);
-  } else {
-    return npmAudit;
   }
+  return npmAudit;
 }
 
 function runNpmAudit(callback) {

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -99,12 +99,12 @@ function runAndReportYarnAudit(config) {
         console.warn('\x1b[33m%s\x1b[0m', msg);
       }
 
+      // Get the levels that have failed by filtering the keys with true values
+      const failedLevelsFound = Object.keys(failedLevels)
+        .filter(l => failedLevels[l])
+        .join(', ');
       // If any of the levels have been failed
-      if (Object.values(failedLevels).some(val => val)) {
-        // Get the levels that have failed by filtering the keys with true values
-        const failedLevelsFound = Object.keys(failedLevels)
-          .filter(l => failedLevels[l])
-          .join(', ');
+      if (failedLevelsFound) {
         const err = `Failed security audit due to ${failedLevelsFound} vulnerabilities.`;
         reject(Error(err));
       } else {


### PR DESCRIPTION
Parsing the advisories is more consistent across yarn and npm auditors.
There is still a lot of duplication.
This commit simplifies consolidation in the future