### PR TITLE
fix(tests): Updated npm test package-lock.json package names

### DIFF
--- a/test/npm-critical/package-lock.json
+++ b/test/npm-critical/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "audit-ci-critical-vulnerability",
+  "name": "audit-ci-npm-critical-vulnerability",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/test/npm-high/package-lock.json
+++ b/test/npm-high/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "audit-ci-high-vulnerability",
+  "name": "audit-ci-npm-high-vulnerability",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/test/npm-low/package-lock.json
+++ b/test/npm-low/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "audit-ci-low-vulnerability",
+  "name": "audit-ci-npm-low-vulnerability",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/test/npm-moderate/package-lock.json
+++ b/test/npm-moderate/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "audit-ci-moderate-vulnerability",
+  "name": "audit-ci-npm-moderate-vulnerability",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/test/npm-none/package-lock.json
+++ b/test/npm-none/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "audit-ci-no-vulnerability",
+  "name": "audit-ci-npm-no-vulnerability",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {


### PR DESCRIPTION
The `package-lock.json` for NPM tests were outdated due to the yarn update.