### PR TITLE
Fix Yarn output parsing

### DIFF
--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -56,8 +56,7 @@ function runAndReportYarnAudit(config) {
     const whitelistedFound = [];
     let missingLockFile = false;
 
-    let bufferedOutput = "";
-
+    let bufferedOutput = '';
 
     proc.stdout.setEncoding('utf8');
     proc.stdout.on('data', data => {
@@ -73,27 +72,28 @@ function runAndReportYarnAudit(config) {
       }
     });
     proc.on('close', () => {
-      bufferedOutput.split('\n')
-      .filter((line) => line.trim().length > 0)
-      .forEach((jsonBlob) => {
-        const auditLine = JSON.parse(jsonBlob);
-        const { type, data } = auditLine;
-        if (report) {
-          console.log(JSON.stringify(auditLine, null, 2));
-        }
-        if (type === 'auditAdvisory') {
-          const { module_name: moduleName, severity } = data.advisory;
-          if (levels[severity]) {
-            if (whitelist.some(m => m === moduleName)) {
-              whitelistedFound.push(moduleName);
-            } else {
-              failedLevels[severity] = true;
-            }
+      bufferedOutput
+        .split('\n')
+        .filter(line => line.trim().length > 0)
+        .forEach(jsonBlob => {
+          const auditLine = JSON.parse(jsonBlob);
+          const { type, data } = auditLine;
+          if (report) {
+            console.log(JSON.stringify(auditLine, null, 2));
           }
-        } else if (type === 'info' && data === 'No lockfile found.') {
-          missingLockFile = true;
-        }
-      });
+          if (type === 'auditAdvisory') {
+            const { module_name: moduleName, severity } = data.advisory;
+            if (levels[severity]) {
+              if (whitelist.some(m => m === moduleName)) {
+                whitelistedFound.push(moduleName);
+              } else {
+                failedLevels[severity] = true;
+              }
+            }
+          } else if (type === 'info' && data === 'No lockfile found.') {
+            missingLockFile = true;
+          }
+        });
 
       if (missingLockFile) {
         console.warn(
@@ -127,4 +127,3 @@ function audit(config) {
 }
 
 module.exports = { audit };
-

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -56,26 +56,13 @@ function runAndReportYarnAudit(config) {
     const whitelistedFound = [];
     let missingLockFile = false;
 
+    let bufferedOutput = "";
+
+
     proc.stdout.setEncoding('utf8');
-    proc.stdout.on('data', jsonl => {
+    proc.stdout.on('data', data => {
       /** @type {{ type: string, data: any }} */
-      const auditLine = JSON.parse(jsonl);
-      const { type, data } = auditLine;
-      if (report) {
-        console.log(JSON.stringify(auditLine, null, 2));
-      }
-      if (type === 'auditAdvisory') {
-        const { module_name: moduleName, severity } = data.advisory;
-        if (levels[severity]) {
-          if (whitelist.some(m => m === moduleName)) {
-            whitelistedFound.push(moduleName);
-          } else {
-            failedLevels[severity] = true;
-          }
-        }
-      } else if (type === 'info' && data === 'No lockfile found.') {
-        missingLockFile = true;
-      }
+      bufferedOutput += data;
     });
     proc.stderr.setEncoding('utf8');
     proc.stderr.on('data', jsonl => {
@@ -86,6 +73,28 @@ function runAndReportYarnAudit(config) {
       }
     });
     proc.on('close', () => {
+      bufferedOutput.split('\n')
+      .filter((line) => line.trim().length > 0)
+      .forEach((jsonBlob) => {
+        const auditLine = JSON.parse(jsonBlob);
+        const { type, data } = auditLine;
+        if (report) {
+          console.log(JSON.stringify(auditLine, null, 2));
+        }
+        if (type === 'auditAdvisory') {
+          const { module_name: moduleName, severity } = data.advisory;
+          if (levels[severity]) {
+            if (whitelist.some(m => m === moduleName)) {
+              whitelistedFound.push(moduleName);
+            } else {
+              failedLevels[severity] = true;
+            }
+          }
+        } else if (type === 'info' && data === 'No lockfile found.') {
+          missingLockFile = true;
+        }
+      });
+
       if (missingLockFile) {
         console.warn(
           '\x1b[33m%s\x1b[0m',
@@ -118,3 +127,4 @@ function audit(config) {
 }
 
 module.exports = { audit };
+


### PR DESCRIPTION
It appears that yarn (or the underlying node process abstractions) do not guarantee that each line emitted by the process will be a complete json blob.

This change buffers the output of the audit command into a single string, then splits it on newlines and parses each line. This ensures that no matter what chunks the yarn child process emits, we'll parse complete JSON blobs.