### PR TITLE
feat(advisory): Whitelist advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,16 @@ before_install:
 
 ## Options
 
-| Args | Alias             | Description                                                                    |
-| ---- | ----------------- | ------------------------------------------------------------------------------ |
-| -l   | --low             | Prevents integration with low or higher vulnerabilities (default `false`)      |
-| -m   | --moderate        | Prevents integration with moderate or higher vulnerabilities (default `false`) |
-| -h   | --high            | Prevents integration with high or critical vulnerabilities (default `false`)   |
-| -c   | --critical        | Prevents integration only with critical vulnerabilities (default `false`)      |
-| -p   | --package-manager | Choose a package manager [_choices_: `auto`, `npm`, `yarn`] (default `auto`)   |
-| -r   | --report          | Shows the `npm audit --json` report (default `true`)                           |
-| -w   | --whitelist       | Vulnerable modules to whitelist from preventing integration (default `none`)   |
+| Args | Alias             | Description                                                                       |
+| ---- | ----------------- | --------------------------------------------------------------------------------- |
+| -l   | --low             | Prevents integration with low or higher vulnerabilities (default `false`)         |
+| -m   | --moderate        | Prevents integration with moderate or higher vulnerabilities (default `false`)    |
+| -h   | --high            | Prevents integration with high or critical vulnerabilities (default `false`)      |
+| -c   | --critical        | Prevents integration only with critical vulnerabilities (default `false`)         |
+| -p   | --package-manager | Choose a package manager [_choices_: `auto`, `npm`, `yarn`] (default `auto`)      |
+| -r   | --report          | Shows the `npm audit --json` report (default `true`)                              |
+| -a   | --advisories      | Vulnerable advisory ids to whitelist from preventing integration (default `none`) |
+| -w   | --whitelist       | Vulnerable modules to whitelist from preventing integration (default `none`)      |
 
 ## Examples
 
@@ -85,10 +86,10 @@ before_install:
 audit-ci -m
 ```
 
-### Prevents build on any vulnerability except lodash (low) and base64url (moderate)
+### Prevents build on any vulnerability except advisory 690 and all of lodash and base64url
 
 ```sh
-audit-ci -l -w lodash base64url
+audit-ci -l -a 690 -w lodash base64url
 ```
 
 ### Prevents build with critical vulnerabilities using aliases without showing the report

--- a/lib/audit-ci.js
+++ b/lib/audit-ci.js
@@ -44,10 +44,16 @@ const { argv } = yargs
       describe: 'Show NPM audit report',
       type: 'boolean',
     },
+    a: {
+      alias: 'advisories',
+      default: [],
+      describe: 'Whitelisted advisory ids',
+      type: 'array',
+    },
     w: {
       alias: 'whitelist',
       default: [],
-      describe: 'Whitelisted vulnerabilities',
+      describe: 'Whitelisted module names',
       type: 'array',
     },
   })

--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -74,12 +74,11 @@ function runNpmAudit(callback) {
 /**
  * Audit your NPM project!
  *
- * @param {{report: boolean, whitelist: string[], low: boolean, moderate: boolean, high: boolean, critical: boolean}} config
+ * @param {{report: boolean, whitelist: string[], advisories: string[], levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
  * `report`: whether to show the NPM audit report in the console.
  * `whitelist`: a list of packages that should not break the build if their vulnerability is found.
- * Only the lowest vulnerability you don't want from [`low`, `moderate`, `high`, `critical`]
- * needs to be set `true`. If `moderate` is set `true` then any of
- * `moderate`, `high`, or `critical` vulnerabilities will return rejections.
+ * `advisories`: a list of advisory ids that should not break the build if found.
+ * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
  * @returns {Promise<any>} Returns the audit report on resolve, `Error` on rejection.
  */
 function audit(config) {

--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -6,7 +6,7 @@
 const childProcess = require('child_process');
 
 function reportAudit(npmAudit, config) {
-  const { levels, whitelist } = config;
+  const { advisories, levels, whitelist } = config;
   if (whitelist.length) {
     console.log(
       '\x1b[36m%s\x1b[0m',
@@ -25,24 +25,32 @@ function reportAudit(npmAudit, config) {
     high: false,
     critical: false,
   };
-  const whitelistedFound = [];
+  const whitelistedModulesFound = [];
+  const whitelistedAdvisoriesFound = [];
 
   Object.keys(npmAudit.advisories)
     // Get the advisories values (Object.values not supported in Node 6)
     .map(k => npmAudit.advisories[k])
     // Remove advisories that have a level that doesn't fail the build
     .filter(({ severity }) => levels[severity])
-    .forEach(({ module_name: moduleName, severity }) => {
+    .forEach(({ id, module_name: moduleName, severity }) => {
       if (whitelist.some(m => m === moduleName)) {
-        whitelistedFound.push(moduleName);
+        whitelistedModulesFound.push(moduleName);
+      } else if (advisories.some(a => +a === id)) {
+        whitelistedAdvisoriesFound.push(id);
       } else {
         failedLevels[severity] = true;
       }
     });
 
-  if (whitelistedFound.length) {
-    const found = whitelistedFound.join(', ');
+  if (whitelistedModulesFound.length) {
+    const found = whitelistedModulesFound.join(', ');
     const msg = `Vulnerable whitelisted modules found: ${found}.`;
+    console.warn('\x1b[33m%s\x1b[0m', msg);
+  }
+  if (whitelistedAdvisoriesFound.length) {
+    const found = whitelistedAdvisoriesFound.join(', ');
+    const msg = `Vulnerable whitelisted advisories found: ${found}.`;
     console.warn('\x1b[33m%s\x1b[0m', msg);
   }
 

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -21,10 +21,17 @@ function yarnSupportsAudit(yarnVersion) {
   return semver.gte(yarnVersion, MINIMUM_YARN_VERSION);
 }
 
-// Yarn uses a JSON-line format for audits.
-// Rather than running a single exec and post-processing the result,
-// we audit each line sequentially. This reduces memory consumption.
-function runAndReportYarnAudit(config) {
+/**
+ * Audit your NPM project!
+ *
+ * @param {{report: boolean, whitelist: string[], advisories: string[], levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
+ * `report`: whether to show the NPM audit report in the console.
+ * `whitelist`: a list of packages that should not break the build if their vulnerability is found.
+ * `advisories`: a list of advisory ids that should not break the build if found.
+ * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
+ * @returns {Promise<none>} Returns nothing on resolve, `Error` on rejection.
+ */
+function audit(config) {
   return new Promise((resolve, reject) => {
     const yarnVersion = getYarnVersion();
     const isYarnVersionSupported = yarnSupportsAudit(yarnVersion);
@@ -120,10 +127,6 @@ function runAndReportYarnAudit(config) {
       }
     });
   });
-}
-
-function audit(config) {
-  return runAndReportYarnAudit(config);
 }
 
 module.exports = { audit };

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -43,10 +43,9 @@ function audit(config) {
       );
     }
 
-    const jsonLinesResults = [];
     const proc = spawn('yarn', ['audit', '--json']);
 
-    const { levels, report, whitelist } = config;
+    const { advisories, levels, report, whitelist } = config;
     if (whitelist.length) {
       console.log(`Modules to whitelist: ${whitelist.join(', ')}.`);
     }
@@ -60,7 +59,8 @@ function audit(config) {
       high: false,
       critical: false,
     };
-    const whitelistedFound = [];
+    const whitelistedModulesFound = [];
+    const whitelistedAdvisoriesFound = [];
     let missingLockFile = false;
 
     let bufferedOutput = '';
@@ -89,10 +89,12 @@ function audit(config) {
             console.log(JSON.stringify(auditLine, null, 2));
           }
           if (type === 'auditAdvisory') {
-            const { module_name: moduleName, severity } = data.advisory;
+            const { id, module_name: moduleName, severity } = data.advisory;
             if (levels[severity]) {
               if (whitelist.some(m => m === moduleName)) {
-                whitelistedFound.push(moduleName);
+                whitelistedModulesFound.push(moduleName);
+              } else if (advisories.some(a => +a === id)) {
+                whitelistedAdvisoriesFound.push(id);
               } else {
                 failedLevels[severity] = true;
               }
@@ -108,9 +110,14 @@ function audit(config) {
           'No yarn.lock file. This does not affect auditing, but it may be a mistake.'
         );
       }
-      if (whitelistedFound.length) {
-        const found = whitelistedFound.join(', ');
+      if (whitelistedModulesFound.length) {
+        const found = whitelistedModulesFound.join(', ');
         const msg = `Vulnerable whitelisted modules found: ${found}.`;
+        console.warn('\x1b[33m%s\x1b[0m', msg);
+      }
+      if (whitelistedAdvisoriesFound.length) {
+        const found = whitelistedAdvisoriesFound.join(', ');
+        const msg = `Vulnerable whitelisted advisories found: ${found}.`;
         console.warn('\x1b[33m%s\x1b[0m', msg);
       }
 
@@ -123,7 +130,7 @@ function audit(config) {
         const err = `Failed security audit due to ${failedLevelsFound} vulnerabilities.`;
         reject(Error(err));
       } else {
-        resolve(jsonLinesResults);
+        resolve();
       }
     });
   });


### PR DESCRIPTION
This allows advisories to be whitelisted on a per-advisory basis instead of a per-module basis.

Addressed https://github.com/IBM/audit-ci/issues/37

Uses the `-a` or `--advisories` arg, pass in the numerical advisory ids.

Example: `audit-ci -l -a 650 651`