### PR TITLE
feat(registry): Add support for specifying registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ before_install:
 | -a   | --advisories      | Vulnerable advisory ids to whitelist from preventing integration (default `none`) |
 | -w   | --whitelist       | Vulnerable modules to whitelist from preventing integration (default `none`)      |
 | -d   | --directory       | The directory containing the package.json to audit. (default `./`)                |
+|      | --registry        | The registry to resolve packages by name and version (default to unspecified)     |
 |      | --config          | Path to JSON config file                                                          |
 
 ### (_Optional_) Config file specification
@@ -96,7 +97,8 @@ A config file can manage auditing preferences `audit-ci`. The config file's keys
   "summary": <boolean>, // [Optional] defaults `true`
   "package-manager": <string>, // [Optional] defaults `"auto"`
   "advisories": <number[]>, // [Optional] defaults `[]`
-  "whitelist": <string[]> // [Optional] defaults `[]`
+  "whitelist": <string[]>, // [Optional] defaults `[]`,
+  "registry": <string> // [Optional] defaults `undefined`
 }
 ```
 
@@ -140,7 +142,8 @@ audit-ci
   "low": true,
   "package-manager": "auto",
   "advisories": [100, 101],
-  "whitelist": ["example1", "example2"]
+  "whitelist": ["example1", "example2"],
+  "registry": "https://registry.npmjs.org"
 }
 ```
 

--- a/lib/audit-ci.js
+++ b/lib/audit-ci.js
@@ -70,6 +70,11 @@ const { argv } = yargs
       describe: 'The directory containing the package.json to audit',
       type: 'string',
     },
+    registry: {
+      default: undefined,
+      describe: 'The registry to resolve packages by name and version',
+      type: 'string',
+    },
   })
   .help('help');
 

--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -6,7 +6,9 @@
 const { runProgram, reportAudit } = require('./common');
 const Model = require('./Model');
 
-function runNpmAudit(directory) {
+function runNpmAudit(config) {
+  const { directory, registry } = config;
+
   const stdoutBuffer = [];
   function outListener(line) {
     stdoutBuffer.push(line);
@@ -18,6 +20,9 @@ function runNpmAudit(directory) {
   }
 
   const args = ['audit', '--json'];
+  if (registry) {
+    args.push('--registry', registry);
+  }
   const options = { cwd: directory };
   return Promise.resolve()
     .then(() => runProgram('npm', args, options, outListener, errListener))
@@ -32,7 +37,7 @@ function runNpmAudit(directory) {
       try {
         return JSON.parse(stdout);
       } catch (e) {
-        console.log(stdout);
+        console.error(stdout);
         throw e;
       }
     });
@@ -53,17 +58,18 @@ function printReport(parsedOutput, report) {
 /**
  * Audit your NPM project!
  *
- * @param {{directory: string, report: { full?: boolean, summary?: boolean }, whitelist: string[], advisories: string[], levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
+ * @param {{directory: string, report: { full?: boolean, summary?: boolean }, whitelist: string[], advisories: string[], registry: string, levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
  * `directory`: the directory containing the package.json to audit.
  * `report`: report level: `full` for full report, `summary` for summary
  * `whitelist`: a list of packages that should not break the build if their vulnerability is found.
  * `advisories`: a list of advisory ids that should not break the build if found.
+ * `registry`: the registry to resolve packages by name and version.
  * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
  * @returns {Promise<any>} Returns the audit report summary on resolve, `Error` on rejection.
  */
 function audit(config, reporter = reportAudit) {
   return Promise.resolve()
-    .then(() => runNpmAudit(config.directory))
+    .then(() => runNpmAudit(config))
     .then(parsedOutput => printReport(parsedOutput, config.report))
     .then(parsedOutput =>
       reporter(new Model(config).load(parsedOutput), config, parsedOutput)

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -9,6 +9,12 @@ const { reportAudit, runProgram } = require('./common');
 const Model = require('./Model');
 
 const MINIMUM_YARN_VERSION = '1.12.3';
+/**
+ * Change this to the appropriate version when
+ * yarn audit --registry is supported:
+ * @see https://github.com/yarnpkg/yarn/issues/7012
+ */
+const MINIMUM_YARN_AUDIT_REGISTRY_VERSION = '99.99.99';
 
 function getYarnVersion() {
   const version = childProcess
@@ -22,20 +28,25 @@ function yarnSupportsAudit(yarnVersion) {
   return semver.gte(yarnVersion, MINIMUM_YARN_VERSION);
 }
 
+function yarnAuditSupportsRegistry(yarnVersion) {
+  return semver.gte(yarnVersion, MINIMUM_YARN_AUDIT_REGISTRY_VERSION);
+}
+
 /**
  * Audit your Yarn project!
  *
- * @param {{directory: string, report: { full?: boolean, summary?: boolean }, whitelist: string[], advisories: string[], levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
+ * @param {{directory: string, report: { full?: boolean, summary?: boolean }, whitelist: string[], advisories: string[], registry: string, levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
  * `directory`: the directory containing the package.json to audit.
  * `report`: report level: `full` for full report, `summary` for summary
  * `whitelist`: a list of packages that should not break the build if their vulnerability is found.
  * `advisories`: a list of advisory ids that should not break the build if found.
+ * `registry`: the registry to resolve packages by name and version.
  * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
  * @returns {Promise<any>} Returns the audit report summary on resolve, `Error` on rejection.
  */
 function audit(config, reporter = reportAudit) {
   return Promise.resolve().then(() => {
-    const { report, whitelist } = config;
+    const { registry, report, whitelist } = config;
     let missingLockFile = false;
     const model = new Model(config);
 
@@ -90,6 +101,17 @@ function audit(config, reporter = reportAudit) {
     }
     const options = { cwd: config.directory };
     const args = ['audit', '--json'];
+    if (registry) {
+      const auditRegistrySupported = yarnAuditSupportsRegistry(yarnVersion);
+      if (auditRegistrySupported) {
+        args.push('--registry', registry);
+      } else {
+        console.warn(
+          '\x1b[33m%s\x1b[0m',
+          'Yarn audit does not support the registry flag yet.'
+        );
+      }
+    }
     return runProgram('yarn', args, options, outListener, errListener).then(
       () => {
         if (missingLockFile) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ./.eslintrc.json lib/*",
-    "test": "mocha --exit --timeout 60000 --recursive --reporter spec test/*.js"
+    "test": "mocha --exit --timeout 40000 --recursive --reporter spec test/*.js"
   },
   "dependencies": {
     "byline": "^5.0.0",

--- a/test/Model.js
+++ b/test/Model.js
@@ -213,7 +213,7 @@ describe('Model', () => {
     });
   });
 
-  it('ignores whitelisted advisotry IDs', () => {
+  it('ignores whitelisted advisory IDs', () => {
     const model = new Model({
       levels: { critical: true, low: true, high: true, moderate: true },
       whitelist: [],

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 /*
  * Copyright IBM All Rights Reserved.
  *

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -180,8 +180,9 @@ describe('npm-auditer', function() {
     });
   });
   // eslint-disable-next-line func-names
-  it('fails with error code ETIMEDOUT on an invalid site', function(cb) {
-    this.slow(25000);
+  it('fails with error code ETIMEDOUT on an invalid site', function(done) {
+    this.slow(50000);
+    this.timeout(120000);
     audit(
       config({
         directory: testDir('npm-low'),
@@ -190,10 +191,10 @@ describe('npm-auditer', function() {
       })
     ).catch(err => {
       expect(err.message).to.include('code ETIMEDOUT');
-      cb();
+      done();
     });
   });
-  it('fails errors with code ENOAUDIT on a valid site with no audit', cb => {
+  it('fails errors with code ENOAUDIT on a valid site with no audit', done => {
     audit(
       config({
         directory: testDir('npm-low'),
@@ -202,7 +203,7 @@ describe('npm-auditer', function() {
       })
     ).catch(err => {
       expect(err.message).to.include('code ENOAUDIT');
-      cb();
+      done();
     });
   });
 });

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -179,18 +179,15 @@ describe('npm-auditer', function() {
       });
     });
   });
-  // eslint-disable-next-line func-names
-  it('fails with error code ETIMEDOUT on an invalid site', function(done) {
-    this.slow(50000);
-    this.timeout(120000);
+  it('fails with error code ENOTFOUND on a non-existent site', done => {
     audit(
       config({
         directory: testDir('npm-low'),
         levels: { low: true },
-        registry: 'https://registry.npmjs.co',
+        registry: 'https://registry.nonexistentdomain0000000000.com',
       })
     ).catch(err => {
-      expect(err.message).to.include('code ETIMEDOUT');
+      expect(err.message).to.include('code ENOTFOUND');
       done();
     });
   });

--- a/test/yarn-auditer.js
+++ b/test/yarn-auditer.js
@@ -8,20 +8,36 @@ const path = require('path');
 const { audit } = require('../lib/yarn-auditer');
 
 function config(additions) {
-  return Object.assign({}, { whitelist: [], advisories: [] }, additions);
+  const defaultConfig = {
+    levels: {
+      low: false,
+      moderate: false,
+      high: false,
+      critical: false,
+    },
+    report: {},
+    advisories: [],
+    whitelist: [],
+    directory: './',
+    registry: undefined,
+  };
+  return Object.assign({}, defaultConfig, additions);
 }
 
 function testDir(s) {
   return path.resolve(__dirname, s);
 }
 
-describe('yarn-auditer', () => {
+// To modify what slow times are, need to use
+// function() {} instead of () => {}
+// eslint-disable-next-line func-names
+describe('yarn-auditer', function() {
+  this.slow(3000);
   it('reports critical severity', () => {
     return audit(
       config({
         directory: testDir('yarn-critical'),
         levels: { critical: true },
-        report: {},
       }),
       summary => summary
     ).then(summary => {
@@ -38,7 +54,6 @@ describe('yarn-auditer', () => {
       config({
         directory: testDir('yarn-critical'),
         levels: { critical: false },
-        report: {},
       }),
       summary => summary
     ).then(summary => {
@@ -55,7 +70,6 @@ describe('yarn-auditer', () => {
       config({
         directory: testDir('yarn-high'),
         levels: { high: true },
-        report: {},
       }),
       summary => summary
     ).then(summary => {
@@ -72,7 +86,6 @@ describe('yarn-auditer', () => {
       config({
         directory: testDir('yarn-moderate'),
         levels: { moderate: true },
-        report: {},
       }),
       summary => summary
     ).then(summary => {
@@ -89,7 +102,6 @@ describe('yarn-auditer', () => {
       config({
         directory: testDir('yarn-moderate'),
         levels: { moderate: false },
-        report: {},
       }),
       summary => summary
     ).then(summary => {
@@ -107,7 +119,6 @@ describe('yarn-auditer', () => {
         directory: testDir('yarn-moderate'),
         levels: { moderate: true },
         advisories: [658],
-        report: {},
       }),
       summary => summary
     ).then(summary => {
@@ -125,7 +136,6 @@ describe('yarn-auditer', () => {
         directory: testDir('yarn-moderate'),
         levels: { moderate: true },
         advisories: [659],
-        report: {},
       }),
       summary => summary
     ).then(summary => {
@@ -142,7 +152,6 @@ describe('yarn-auditer', () => {
       config({
         directory: testDir('yarn-low'),
         levels: { low: true },
-        report: {},
       }),
       summary => summary
     ).then(summary => {
@@ -159,7 +168,6 @@ describe('yarn-auditer', () => {
       config({
         directory: testDir('yarn-none'),
         levels: { low: true },
-        report: {},
       }),
       summary => summary
     ).then(summary => {
@@ -170,5 +178,15 @@ describe('yarn-auditer', () => {
         advisoriesFound: [],
       });
     });
+  });
+  it("doesn't use the registry flag since it's not supported in Yarn yet", () => {
+    return audit(
+      config({
+        directory: testDir('yarn-low'),
+        levels: { low: true },
+        registry: 'https://example.com',
+      }),
+      summary => summary
+    );
   });
 });


### PR DESCRIPTION
From @memelet:

> When using a private repo like nexus that does not response correctly to audit, its necessary to use --registry=https://registry.npmjs.org.

This PR supports specifying a registry for NPM (Yarn [is not supported yet](https://github.com/yarnpkg/yarn/issues/7012)) by adding the `--registry` argument. It is an optional parameter, defaulting to the package manager's standard registry.

Addresses: https://github.com/IBM/audit-ci/issues/46