### PR TITLE
fix(runNpmAudit): Replace error checking from stderr to error

### DIFF
--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -69,13 +69,20 @@ function reportAudit(npmAudit, config) {
 
 function runNpmAudit(callback) {
   childProcess.exec('npm audit --json', (_error, stdout, stderr) => {
-    if (stderr) {
-      callback(new Error(stderr), null);
-      return;
+    if (stdout) {
+      try {
+        const parsedAudit = JSON.parse(stdout);
+        callback(null, parsedAudit);
+        return;
+      } catch (error) {
+        callback(new Error('Invalid output'), null);
+        return;
+      }
     }
 
-    const parsedAudit = JSON.parse(stdout);
-    callback(null, parsedAudit);
+    if (_error) {
+      callback(new Error(stderr), null);
+    }
   });
 }
 


### PR DESCRIPTION
Type of change: **Bug fixing**
Does this introduce a breaking change?: **No**

## Problem description
This pull request tackles down the issue #49 

## Solution description
If something was returned to the output stream, it should be a formatted json, and it tries to parse it. In case there are issues with the output (couldn't parse the JSON) it will return an error.

If the output is empty will check for errors.

Note: You may want to move the `if (_error)` to the top, but the current approach is more optimistic and relays on the output and the output JSON.

## Side Effects
N/A

## Additional comments
Tested on node.js v10.15.1 and npm v6.5.0
