### PR TITLE
chore(release): Minor bump to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Audits npm and yarn projects in CI environments",
   "license": "Apache-2.0",
   "main": "./lib/audit-ci.js",


### PR DESCRIPTION
Diff: https://github.com/IBM/audit-ci/compare/v1.3.1..d2a4ac60

**BREAKING CHANGES**
- The new default output is the summary report rather than the full report.

**Features**

- Unit testing (closes #4) (PR: #53, #54)
- Add `--directory` argument (closes #17) (PR: #53, #56)
- Add option to output summary report (closes #58) (PR: #59)

**Chores**

- Use `spawn` rather than `exec` for NPM (closes #48) (PR: #53)
- Bump ESLint (minor)