### PR TITLE
chore(release): Minor release to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Audits npm and yarn projects in CI environments",
   "license": "Apache-2.0",
   "main": "./lib/audit-ci.js",


### PR DESCRIPTION
**Fixes**

- Handle non-JSON Yarn audit report (closes #45) (PR: #66)

**Chores**

- Address advisories (closes #67) (PR: #68)
- Bump Semver (major) (PR: #68)
- Bump eslint (patch) (PR: #68)

_Minor release due to the new behaviour of Yarn non-JSON audit report_