### PR TITLE
feat: Warn when whitelisted advisories are not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ before_install:
 | -s   | --summary         | Shows the summary audit report (default `true`)                                   |
 | -a   | --advisories      | Vulnerable advisory ids to whitelist from preventing integration (default `none`) |
 | -w   | --whitelist       | Vulnerable modules to whitelist from preventing integration (default `none`)      |
-| -d   | --directory       | The directory containing the package.json to audit. (default `./`)                |
+| -d   | --directory       | The directory containing the package.json to audit (default `./`)                 |
+|      | --show-not-found  | Show whitelisted advisories that are not found (default `true`)                   |
 |      | --registry        | The registry to resolve packages by name and version (default to unspecified)     |
 |      | --config          | Path to JSON config file                                                          |
 
@@ -97,7 +98,8 @@ A config file can manage auditing preferences `audit-ci`. The config file's keys
   "summary": <boolean>, // [Optional] defaults `true`
   "package-manager": <string>, // [Optional] defaults `"auto"`
   "advisories": <number[]>, // [Optional] defaults `[]`
-  "whitelist": <string[]>, // [Optional] defaults `[]`,
+  "whitelist": <string[]>, // [Optional] defaults `[]`
+  "show-whitelisted-advisories": <boolean>, // [Optional] defaults `true`
   "registry": <string> // [Optional] defaults `undefined`
 }
 ```

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -67,9 +67,14 @@ class Model {
 
     const advisoriesFound = this.advisoriesFound.map(advisoryMapper);
 
+    const whitelistedAdvisoriesNotFound = this.whitelistedAdvisoryIds.filter(
+      id => advisoriesFound.indexOf(id) === -1
+    );
+
     return {
       advisoriesFound,
       failedLevelsFound,
+      whitelistedAdvisoriesNotFound,
       whitelistedAdvisoriesFound: this.whitelistedAdvisoriesFound,
       whitelistedModulesFound: this.whitelistedModulesFound,
     };

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -68,7 +68,7 @@ class Model {
     const advisoriesFound = this.advisoriesFound.map(advisoryMapper);
 
     const whitelistedAdvisoriesNotFound = this.whitelistedAdvisoryIds.filter(
-      id => advisoriesFound.indexOf(id) === -1
+      id => this.whitelistedAdvisoriesFound.indexOf(id) === -1
     );
 
     return {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -36,7 +36,7 @@ class Model {
     }
 
     if (this.whitelistedModuleNames.some(m => m === advisory.module_name)) {
-      if (this.whitelistedModulesFound.indexOf(advisory.module_name) === -1) {
+      if (!this.whitelistedModulesFound.includes(advisory.module_name)) {
         this.whitelistedModulesFound.push(advisory.module_name);
       }
       return;
@@ -68,7 +68,7 @@ class Model {
     const advisoriesFound = this.advisoriesFound.map(advisoryMapper);
 
     const whitelistedAdvisoriesNotFound = this.whitelistedAdvisoryIds.filter(
-      id => this.whitelistedAdvisoriesFound.indexOf(id) === -1
+      id => !this.whitelistedAdvisoriesFound.includes(id)
     );
 
     return {

--- a/lib/audit-ci.js
+++ b/lib/audit-ci.js
@@ -70,6 +70,11 @@ const { argv } = yargs
       describe: 'The directory containing the package.json to audit',
       type: 'string',
     },
+    'show-not-found': {
+      default: true,
+      describe: 'Show whitelisted advisories that are not found',
+      type: 'boolean',
+    },
     registry: {
       default: undefined,
       describe: 'The registry to resolve packages by name and version',

--- a/lib/common.js
+++ b/lib/common.js
@@ -7,7 +7,7 @@ const { spawn } = require('cross-spawn');
 const byline = require('byline');
 
 function reportAudit(summary, config) {
-  const { whitelist } = config;
+  const { whitelist, 'show-not-found': showNotFound } = config;
   if (whitelist.length) {
     console.log(
       '\x1b[36m%s\x1b[0m',
@@ -23,6 +23,11 @@ function reportAudit(summary, config) {
   if (summary.whitelistedAdvisoriesFound.length) {
     const found = summary.whitelistedAdvisoriesFound.join(', ');
     const msg = `Vulnerable whitelisted advisories found: ${found}.`;
+    console.warn('\x1b[33m%s\x1b[0m', msg);
+  }
+  if (showNotFound && summary.whitelistedAdvisoriesNotFound.length) {
+    const found = summary.whitelistedAdvisoriesNotFound.join(', ');
+    const msg = `Vulnerable whitelisted advisories not found: ${found}.\nConsider not whitelisting them.`;
     console.warn('\x1b[33m%s\x1b[0m', msg);
   }
 

--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -64,6 +64,7 @@ function printReport(parsedOutput, report) {
  * `whitelist`: a list of packages that should not break the build if their vulnerability is found.
  * `advisories`: a list of advisory ids that should not break the build if found.
  * `registry`: the registry to resolve packages by name and version.
+ * `show-not-found`: show whitelisted advisories that are not found.
  * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
  * @returns {Promise<any>} Returns the audit report summary on resolve, `Error` on rejection.
  */

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -41,6 +41,7 @@ function yarnAuditSupportsRegistry(yarnVersion) {
  * `whitelist`: a list of packages that should not break the build if their vulnerability is found.
  * `advisories`: a list of advisory ids that should not break the build if found.
  * `registry`: the registry to resolve packages by name and version.
+ * `show-not-found`: show whitelisted advisories that are not found.
  * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
  * @returns {Promise<any>} Returns the audit report summary on resolve, `Error` on rejection.
  */

--- a/test/Model.js
+++ b/test/Model.js
@@ -28,6 +28,7 @@ describe('Model', () => {
         )
     ).to.throw('Unsupported severity levels found: hgih, mdrate');
   });
+
   it('returns an empty summary for an empty audit output', () => {
     const model = new Model({
       levels: { critical: true, low: true, high: true, moderate: true },
@@ -43,10 +44,12 @@ describe('Model', () => {
     expect(summary).to.eql({
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [],
+      whitelistedAdvisoriesNotFound: [],
       failedLevelsFound: [],
       advisoriesFound: [],
     });
   });
+
   it('compute a summary', () => {
     const model = new Model({
       levels: { critical: true },
@@ -70,10 +73,12 @@ describe('Model', () => {
     expect(summary).to.eql({
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [],
+      whitelistedAdvisoriesNotFound: [],
       failedLevelsFound: ['critical'],
       advisoriesFound: [663],
     });
   });
+
   it('ignores severities that are set to false', () => {
     const model = new Model({
       levels: { critical: true, low: true, high: false, moderate: false },
@@ -139,10 +144,12 @@ describe('Model', () => {
     expect(summary).to.eql({
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [],
+      whitelistedAdvisoriesNotFound: [],
       failedLevelsFound: ['critical', 'low'],
       advisoriesFound: [1, 2, 5, 6, 7],
     });
   });
+
   it('ignores whitelisted modules', () => {
     const model = new Model({
       levels: { critical: true, low: true, high: true, moderate: true },
@@ -208,6 +215,7 @@ describe('Model', () => {
     expect(summary).to.eql({
       whitelistedModulesFound: ['M_A', 'M_D'],
       whitelistedAdvisoriesFound: [],
+      whitelistedAdvisoriesNotFound: [],
       failedLevelsFound: ['critical', 'low', 'moderate'],
       advisoriesFound: [2, 3, 5, 6, 7],
     });
@@ -278,6 +286,7 @@ describe('Model', () => {
     expect(summary).to.eql({
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [2, 3, 6],
+      whitelistedAdvisoriesNotFound: [],
       failedLevelsFound: ['critical', 'high', 'low'],
       advisoriesFound: [1, 4, 5, 7],
     });
@@ -313,6 +322,7 @@ describe('Model', () => {
     expect(summary).to.eql({
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [],
+      whitelistedAdvisoriesNotFound: [],
       failedLevelsFound: ['critical', 'low'],
       advisoriesFound: [1, 2],
     });

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -18,6 +18,7 @@ function config(additions) {
     report: {},
     advisories: [],
     whitelist: [],
+    'show-not-found': false,
     directory: './',
     registry: undefined,
   };
@@ -44,6 +45,7 @@ describe('npm-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['critical'],
         advisoriesFound: [663],
       });
@@ -60,6 +62,7 @@ describe('npm-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -76,6 +79,7 @@ describe('npm-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['high'],
         advisoriesFound: [690],
       });
@@ -92,6 +96,7 @@ describe('npm-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['moderate'],
         advisoriesFound: [658],
       });
@@ -108,6 +113,7 @@ describe('npm-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -125,6 +131,7 @@ describe('npm-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [658],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -142,6 +149,7 @@ describe('npm-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [659],
         failedLevelsFound: ['moderate'],
         advisoriesFound: [658],
       });
@@ -158,6 +166,7 @@ describe('npm-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['low'],
         advisoriesFound: [577],
       });
@@ -174,6 +183,7 @@ describe('npm-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });

--- a/test/yarn-auditer.js
+++ b/test/yarn-auditer.js
@@ -18,6 +18,7 @@ function config(additions) {
     report: {},
     advisories: [],
     whitelist: [],
+    'show-not-found': false,
     directory: './',
     registry: undefined,
   };
@@ -44,6 +45,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['critical'],
         advisoriesFound: [663],
       });
@@ -60,6 +62,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -76,6 +79,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['high'],
         advisoriesFound: [690],
       });
@@ -92,6 +96,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['moderate'],
         advisoriesFound: [658],
       });
@@ -108,6 +113,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -125,6 +131,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [658],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -142,6 +149,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [659],
         failedLevelsFound: ['moderate'],
         advisoriesFound: [658],
       });
@@ -158,6 +166,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['low'],
         advisoriesFound: [577],
       });
@@ -174,6 +183,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });


### PR DESCRIPTION
`audit-ci.json` files that contain advisories can become outdated when dependencies are updated. What once was a vulnerable package may not be anymore.

Advisories that are whitelisted that are not found should likely be removed from the whitelist for cleanliness and reducing the risk of whitelisting an unacknowledged advisory for another module.

This changes existing behaviour, as the setting defaults to `true`.

Closes: #70