### PR TITLE
Print yarn's output when it crashes with an error

### DIFF
--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -43,11 +43,13 @@ function yarnAuditSupportsRegistry(yarnVersion) {
  * `registry`: the registry to resolve packages by name and version.
  * `show-not-found`: show whitelisted advisories that are not found.
  * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
+ * `yarn`: a path to yarn, uses yarn from PATH if not specified.
  * @returns {Promise<any>} Returns the audit report summary on resolve, `Error` on rejection.
  */
 function audit(config, reporter = reportAudit) {
   return Promise.resolve().then(() => {
     const { registry, report, whitelist } = config;
+    const yarnExec = config.yarn || 'yarn';
     let missingLockFile = false;
     const model = new Model(config);
 
@@ -103,8 +105,22 @@ function audit(config, reporter = reportAudit) {
       }
     }
 
+    let isFatalError = false;
+    const stderrBuffer = [];
     function errListener(line) {
-      const errorLine = JSON.parse(line);
+      stderrBuffer.push(line);
+      if (isFatalError) {
+        return;
+      }
+
+      let errorLine;
+      try {
+        errorLine = JSON.parse(line);
+      } catch (e) {
+        isFatalError = true;
+        return;
+      }
+
       if (errorLine.type === 'error') {
         throw new Error(errorLine.data);
       }
@@ -122,8 +138,14 @@ function audit(config, reporter = reportAudit) {
         );
       }
     }
-    return runProgram('yarn', args, options, outListener, errListener).then(
+    return runProgram(yarnExec, args, options, outListener, errListener).then(
       () => {
+        if (isFatalError) {
+          throw new Error(
+            `Invocation of yarn audit failed:\n${stderrBuffer.join('\n')}`
+          );
+        }
+
         if (missingLockFile) {
           console.warn(
             '\x1b[33m%s\x1b[0m',

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -43,13 +43,13 @@ function yarnAuditSupportsRegistry(yarnVersion) {
  * `registry`: the registry to resolve packages by name and version.
  * `show-not-found`: show whitelisted advisories that are not found.
  * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
- * `yarn`: a path to yarn, uses yarn from PATH if not specified.
+ * `_yarn`: a path to yarn, uses yarn from PATH if not specified.
  * @returns {Promise<any>} Returns the audit report summary on resolve, `Error` on rejection.
  */
 function audit(config, reporter = reportAudit) {
   return Promise.resolve().then(() => {
-    const { registry, report, whitelist } = config;
-    const yarnExec = config.yarn || 'yarn';
+    const { registry, report, whitelist, _yarn } = config;
+    const yarnExec = _yarn || 'yarn';
     let missingLockFile = false;
     const model = new Model(config);
 

--- a/test/yarn-auditer.js
+++ b/test/yarn-auditer.js
@@ -34,6 +34,26 @@ function testDir(s) {
 // eslint-disable-next-line func-names
 describe('yarn-auditer', function() {
   this.slow(3000);
+  it('prints yarn errors', () => {
+    const directory = testDir('yarn-error');
+    const errorMessagePath = path.resolve(directory, 'error-message');
+    const errorMessage = require(errorMessagePath); // eslint-disable-line
+
+    return audit(
+      config({
+        directory,
+        registry: 'https://example.com',
+        yarn: path.join(directory, 'yarn'),
+      })
+    )
+      .then(() => {
+        // Since we expect an error the promise should never resolve
+        throw new Error();
+      })
+      .catch(err => {
+        expect(err.toString()).to.contain(errorMessage);
+      });
+  });
   it('reports critical severity', () => {
     return audit(
       config({

--- a/test/yarn-auditer.js
+++ b/test/yarn-auditer.js
@@ -34,7 +34,7 @@ function testDir(s) {
 // eslint-disable-next-line func-names
 describe('yarn-auditer', function() {
   this.slow(3000);
-  it('prints yarn errors', () => {
+  it('prints unexpected https://registry.yarnpkg.com 503 error message', () => {
     const directory = testDir('yarn-error');
     const errorMessagePath = path.resolve(directory, 'error-message');
     const errorMessage = require(errorMessagePath); // eslint-disable-line
@@ -42,8 +42,7 @@ describe('yarn-auditer', function() {
     return audit(
       config({
         directory,
-        registry: 'https://example.com',
-        yarn: path.join(directory, 'yarn'),
+        _yarn: path.join(directory, 'yarn'),
       })
     )
       .then(() => {

--- a/test/yarn-error/error-message.js
+++ b/test/yarn-error/error-message.js
@@ -1,0 +1,15 @@
+module.exports = `/usr/local/lib/node_modules/yarn/lib/cli.js:66237
+            throw new (_errors || _load_errors()).ResponseError(_this3.reporter.lang('requestFailed', description), res.statusCode);
+            ^
+Error: Request failed "503 Service Unavailable"
+    at ResponseError.ExtendableBuiltin (/usr/local/lib/node_modules/yarn/lib/cli.js:702:66)
+    at new ResponseError (/usr/local/lib/node_modules/yarn/lib/cli.js:808:124)
+    at Request.params.callback [as _callback] (/usr/local/lib/node_modules/yarn/lib/cli.js:66237:19)
+    at Request.self.callback (/usr/local/lib/node_modules/yarn/lib/cli.js:129397:22)
+    at Request.emit (events.js:193:13)
+    at Request.<anonymous> (/usr/local/lib/node_modules/yarn/lib/cli.js:130369:10)
+    at Request.emit (events.js:193:13)
+    at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/yarn/lib/cli.js:130291:12)
+    at Object.onceWrapper (events.js:281:20)
+    at IncomingMessage.emit (events.js:198:15)
+Exiting...`;

--- a/test/yarn-error/yarn
+++ b/test/yarn-error/yarn
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+const path = require('path');
+
+const errorMessagePath = path.resolve(__dirname, 'error-message.js');
+const errorMessage = require(errorMessagePath); //eslint-disable-line
+
+console.error(errorMessage);
+process.exitCode = 1;

--- a/test/yarn-error/yarn
+++ b/test/yarn-error/yarn
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const path = require('path');
 
-const errorMessagePath = path.resolve(__dirname, 'error-message.js');
+const errorMessagePath = path.resolve(__dirname, 'error-message');
 const errorMessage = require(errorMessagePath); //eslint-disable-line
 
 console.error(errorMessage);


### PR DESCRIPTION
Follows #66, fixes #45 