### PR TITLE
chore(release): Minor release to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Audits npm and yarn projects in CI environments",
   "license": "Apache-2.0",
   "main": "./lib/audit-ci.js",


### PR DESCRIPTION
**Features**

- Warn when whitelisted advisories are not found (closes #70) (PR: #73)

**Fixes**

- Handle non-JSON Yarn audit report (re-closes #45) (PR: #66 and #76)
- Fix broken link in README (PR: #78) 

**Chores**

- Update `.travis.yml` config to use the `cache: npm` shortcut and provide more docs (PR: #79)
- Fix advisories (fixes #67) (PR: #68 and #80)
- Bump Mocha (minor) (PR: #80)
- Bump ESLint (minor) (PR: #80)

_Minor release due to the new behaviour of Yarn non-JSON audit report and warning when whitelisted advisories are not found_