### PR TITLE
Fix retry mechanism for other version of NPM error message.

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -9,7 +9,7 @@ function audit(pm, config, reporter) {
       config.registry
         ? `npm ERR! audit Your configured registry (${config.registry}) `
         : ''
-    }does not support audit requests.`,
+    }does not support audit requests`,
     yarn: '503 Service Unavailable',
   };
 


### PR DESCRIPTION
Hello!
In a previous comment https://github.com/IBM/audit-ci/issues/86#issuecomment-496798003 I talked about the retry mechanism that seemed broken for my project using NPM.
After taking a quick look, I saw that the error message given by NPM is not the same for me:

```
npm ERR! code ENOAUDIT
npm ERR! audit Your configured registry (https://registry.npmjs.org/) does not support audit requests, or the audit endpoint is temporarily unavailable.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/circleci/.npm/_logs/2019-05-20T12_16_22_839Z-debug.log
```

At the end of the second line, `, or the audit endpoint is temporarily unavailable` is added compared to what is compared in the retry mechanism. To make it work for both cases, I just removed the dot at the end.

What do you think?

Thank you