### PR TITLE
Change low vulnerability dependency test

### DIFF
--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -174,7 +174,7 @@ describe('npm-auditer', function() {
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['low'],
-        advisoriesFound: [577],
+        advisoriesFound: [722],
       });
     });
   });

--- a/test/npm-low/package-lock.json
+++ b/test/npm-low/package-lock.json
@@ -3,10 +3,10 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     }
   }
 }

--- a/test/npm-low/package.json
+++ b/test/npm-low/package.json
@@ -2,6 +2,6 @@
   "name": "audit-ci-npm-low-vulnerability",
   "description": "Test package.json with low vulnerability",
   "dependencies": {
-    "lodash": "4.17.4"
+    "merge": "1.2.0"
   }
 }

--- a/test/yarn-auditer.js
+++ b/test/yarn-auditer.js
@@ -173,7 +173,7 @@ describe('yarn-auditer', function() {
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
         failedLevelsFound: ['low'],
-        advisoriesFound: [577],
+        advisoriesFound: [722],
       });
     });
   });

--- a/test/yarn-low/package.json
+++ b/test/yarn-low/package.json
@@ -2,6 +2,6 @@
   "name": "audit-ci-yarn-low-vulnerability",
   "description": "Test package.json with low vulnerability",
   "dependencies": {
-    "lodash": "4.17.4"
+    "merge": "1.2.0"
   }
 }

--- a/test/yarn-low/yarn.lock
+++ b/test/yarn-low/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-lodash@4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-  integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
+merge@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
+  integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=


### PR DESCRIPTION
`lodash` now has high vulnerabilities, so the test is incorrect. `merge` has a low vulnerability.