### PR TITLE
Add "path-whitelist" option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ before_install:
 | -p   | --package-manager | Choose a package manager [_choices_: `auto`, `npm`, `yarn`] (default `auto`)                          |
 | -a   | --advisories      | Vulnerable advisory ids to whitelist from preventing integration (default `none`)                     |
 | -w   | --whitelist       | Vulnerable modules to whitelist from preventing integration (default `none`)                          |
+|      | --path-whitelist  | Vulnerable module paths to whitelist from preventing integration (default `none`)                     |
 | -d   | --directory       | The directory containing the package.json to audit (default `./`)                                     |
 |      | --pass-enoaudit   | Pass if no audit is performed due to the registry returning ENOAUDIT (default `false`)                |
 |      | --show-not-found  | Show whitelisted advisories that are not found (default `true`)                                       |
@@ -101,6 +102,7 @@ A config file can manage auditing preferences `audit-ci`. The config file's keys
   "package-manager": <string>, // [Optional] defaults `"auto"`
   "advisories": <number[]>, // [Optional] defaults `[]`
   "whitelist": <string[]>, // [Optional] defaults `[]`
+  "path-whitelist": <string[]>, // [Optional] defaults `[]`
   "pass-enoaudit": <boolean>, // [Optional] defaults `false`
   "show-not-found": <boolean>, // [Optional] defaults `true`
   "registry": <string>, // [Optional] defaults `undefined`
@@ -149,6 +151,7 @@ audit-ci --report-type summary
   "package-manager": "auto",
   "advisories": [100, 101],
   "whitelist": ["example1", "example2"],
+  "path-whitelist": ["52|example3"],
   "registry": "https://registry.npmjs.org"
 }
 ```

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -23,10 +23,12 @@ class Model {
     this.failingSeverities = config.levels;
 
     this.whitelistedModuleNames = config.whitelist;
+    this.whitelistedPaths = config['path-whitelist'] || [];
     this.whitelistedAdvisoryIds = config.advisories;
 
     this.whitelistedModulesFound = [];
     this.whitelistedAdvisoriesFound = [];
+    this.whitelistedPathsFound = [];
     this.advisoriesFound = [];
   }
 
@@ -44,6 +46,24 @@ class Model {
 
     if (this.whitelistedAdvisoryIds.some(a => Number(a) === advisory.id)) {
       this.whitelistedAdvisoriesFound.push(advisory.id);
+      return;
+    }
+
+    advisory.findings.forEach(finding =>
+      finding.paths.forEach(path => {
+        if (this.whitelistedPaths.includes(`${advisory.id}|${path}`)) {
+          this.whitelistedPathsFound.push(`${advisory.id}|${path}`);
+        }
+      })
+    );
+
+    if (
+      advisory.findings.every(finding =>
+        finding.paths.every(path =>
+          this.whitelistedPaths.includes(`${advisory.id}|${path}`)
+        )
+      )
+    ) {
       return;
     }
 
@@ -77,6 +97,7 @@ class Model {
       whitelistedAdvisoriesNotFound,
       whitelistedAdvisoriesFound: this.whitelistedAdvisoriesFound,
       whitelistedModulesFound: this.whitelistedModulesFound,
+      whitelistedPathsFound: this.whitelistedPathsFound,
     };
   }
 }

--- a/lib/audit-ci.js
+++ b/lib/audit-ci.js
@@ -98,6 +98,11 @@ const { argv } = yargs
         'Pass if no audit is performed due to the registry returning ENOAUDIT',
       type: 'boolean',
     },
+    'path-whitelist': {
+      default: [],
+      describe: 'Whitelisted vulnerability paths',
+      type: 'array',
+    },
   })
   .help('help');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,10 +1328,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/test/Model.js
+++ b/test/Model.js
@@ -44,6 +44,7 @@ describe('Model', () => {
     expect(summary).to.eql({
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [],
+      whitelistedPathsFound: [],
       whitelistedAdvisoriesNotFound: [],
       failedLevelsFound: [],
       advisoriesFound: [],
@@ -65,6 +66,7 @@ describe('Model', () => {
           module_name: 'open',
           severity: 'critical',
           url: 'https://npmjs.com/advisories/663',
+          findings: [{ paths: ['open'] }],
         },
       },
     };
@@ -74,6 +76,7 @@ describe('Model', () => {
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [],
       whitelistedAdvisoriesNotFound: [],
+      whitelistedPathsFound: [],
       failedLevelsFound: ['critical'],
       advisoriesFound: [663],
     });
@@ -94,6 +97,7 @@ describe('Model', () => {
           module_name: 'M_A',
           severity: 'critical',
           url: 'https://A',
+          findings: [{ paths: ['M_A'] }],
         },
         2: {
           id: 2,
@@ -101,6 +105,7 @@ describe('Model', () => {
           module_name: 'M_B',
           severity: 'low',
           url: 'https://B',
+          findings: [{ paths: ['M_B'] }],
         },
         3: {
           id: 3,
@@ -108,6 +113,7 @@ describe('Model', () => {
           module_name: 'M_C',
           severity: 'moderate',
           url: 'https://C',
+          findings: [{ paths: ['M_C'] }],
         },
         4: {
           id: 4,
@@ -115,6 +121,7 @@ describe('Model', () => {
           module_name: 'M_D',
           severity: 'high',
           url: 'https://D',
+          findings: [{ paths: ['M_D'] }],
         },
         5: {
           id: 5,
@@ -122,6 +129,7 @@ describe('Model', () => {
           module_name: 'M_E',
           severity: 'critical',
           url: 'https://E',
+          findings: [{ paths: ['M_E'] }],
         },
         6: {
           id: 6,
@@ -129,6 +137,7 @@ describe('Model', () => {
           module_name: 'M_F',
           severity: 'low',
           url: 'https://F',
+          findings: [{ paths: ['M_F'] }],
         },
         7: {
           id: 7,
@@ -136,6 +145,7 @@ describe('Model', () => {
           module_name: 'M_G',
           severity: 'low',
           url: 'https://G',
+          findings: [{ paths: ['M_G'] }],
         },
       },
     };
@@ -145,6 +155,7 @@ describe('Model', () => {
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [],
       whitelistedAdvisoriesNotFound: [],
+      whitelistedPathsFound: [],
       failedLevelsFound: ['critical', 'low'],
       advisoriesFound: [1, 2, 5, 6, 7],
     });
@@ -165,6 +176,7 @@ describe('Model', () => {
           module_name: 'M_A',
           severity: 'critical',
           url: 'https://A',
+          findings: [{ paths: ['M_A'] }],
         },
         2: {
           id: 2,
@@ -172,6 +184,7 @@ describe('Model', () => {
           module_name: 'M_B',
           severity: 'low',
           url: 'https://B',
+          findings: [{ paths: ['M_B'] }],
         },
         3: {
           id: 3,
@@ -179,6 +192,7 @@ describe('Model', () => {
           module_name: 'M_C',
           severity: 'moderate',
           url: 'https://C',
+          findings: [{ paths: ['M_C'] }],
         },
         4: {
           id: 4,
@@ -186,6 +200,7 @@ describe('Model', () => {
           module_name: 'M_D',
           severity: 'high',
           url: 'https://D',
+          findings: [{ paths: ['M_D'] }],
         },
         5: {
           id: 5,
@@ -193,6 +208,7 @@ describe('Model', () => {
           module_name: 'M_E',
           severity: 'critical',
           url: 'https://E',
+          findings: [{ paths: ['M_E'] }],
         },
         6: {
           id: 6,
@@ -200,6 +216,7 @@ describe('Model', () => {
           module_name: 'M_F',
           severity: 'low',
           url: 'https://F',
+          findings: [{ paths: ['M_F'] }],
         },
         7: {
           id: 7,
@@ -207,6 +224,7 @@ describe('Model', () => {
           module_name: 'M_G',
           severity: 'low',
           url: 'https://G',
+          findings: [{ paths: ['M_G'] }],
         },
       },
     };
@@ -216,6 +234,7 @@ describe('Model', () => {
       whitelistedModulesFound: ['M_A', 'M_D'],
       whitelistedAdvisoriesFound: [],
       whitelistedAdvisoriesNotFound: [],
+      whitelistedPathsFound: [],
       failedLevelsFound: ['critical', 'low', 'moderate'],
       advisoriesFound: [2, 3, 5, 6, 7],
     });
@@ -236,6 +255,7 @@ describe('Model', () => {
           module_name: 'M_A',
           severity: 'critical',
           url: 'https://A',
+          findings: [{ paths: ['M_A'] }],
         },
         2: {
           id: 2,
@@ -243,6 +263,7 @@ describe('Model', () => {
           module_name: 'M_B',
           severity: 'low',
           url: 'https://B',
+          findings: [{ paths: ['M_B'] }],
         },
         3: {
           id: 3,
@@ -250,6 +271,7 @@ describe('Model', () => {
           module_name: 'M_C',
           severity: 'moderate',
           url: 'https://C',
+          findings: [{ paths: ['M_C'] }],
         },
         4: {
           id: 4,
@@ -257,6 +279,7 @@ describe('Model', () => {
           module_name: 'M_D',
           severity: 'high',
           url: 'https://D',
+          findings: [{ paths: ['M_D'] }],
         },
         5: {
           id: 5,
@@ -264,6 +287,7 @@ describe('Model', () => {
           module_name: 'M_E',
           severity: 'critical',
           url: 'https://E',
+          findings: [{ paths: ['M_E'] }],
         },
         6: {
           id: 6,
@@ -271,6 +295,7 @@ describe('Model', () => {
           module_name: 'M_F',
           severity: 'low',
           url: 'https://F',
+          findings: [{ paths: ['M_F'] }],
         },
         7: {
           id: 7,
@@ -278,6 +303,7 @@ describe('Model', () => {
           module_name: 'M_G',
           severity: 'low',
           url: 'https://G',
+          findings: [{ paths: ['M_G'] }],
         },
       },
     };
@@ -287,6 +313,7 @@ describe('Model', () => {
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [2, 3, 6],
       whitelistedAdvisoriesNotFound: [],
+      whitelistedPathsFound: [],
       failedLevelsFound: ['critical', 'high', 'low'],
       advisoriesFound: [1, 4, 5, 7],
     });
@@ -307,6 +334,7 @@ describe('Model', () => {
           module_name: 'M_A',
           severity: 'low',
           url: 'https://A',
+          findings: [{ paths: ['M_A'] }],
         },
         2: {
           id: 2,
@@ -314,6 +342,7 @@ describe('Model', () => {
           module_name: 'M_B',
           severity: 'critical',
           url: 'https://B',
+          findings: [{ paths: ['M_B'] }],
         },
       },
     };
@@ -323,6 +352,7 @@ describe('Model', () => {
       whitelistedModulesFound: [],
       whitelistedAdvisoriesFound: [],
       whitelistedAdvisoriesNotFound: [],
+      whitelistedPathsFound: [],
       failedLevelsFound: ['critical', 'low'],
       advisoriesFound: [1, 2],
     });

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -50,6 +50,7 @@ describe('npm-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: ['critical'],
         advisoriesFound: [663],
       });
@@ -67,6 +68,7 @@ describe('npm-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -85,6 +87,7 @@ describe('npm-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: ['high'],
         advisoriesFound: [690],
       });
@@ -103,6 +106,7 @@ describe('npm-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: ['moderate'],
         advisoriesFound: [658],
       });
@@ -120,6 +124,7 @@ describe('npm-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -138,6 +143,7 @@ describe('npm-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [658],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -156,8 +162,47 @@ describe('npm-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [659],
+        whitelistedPathsFound: [],
         failedLevelsFound: ['moderate'],
         advisoriesFound: [658],
+      });
+    });
+  });
+  it('reports only vulnerabilities with a not whitelisted path', () => {
+    return audit(
+      config({
+        directory: testDir('npm-whitelisted-path'),
+        levels: { moderate: true },
+        'path-whitelist': ['880|github-build>axios'],
+      }),
+      summary => summary
+    ).then(summary => {
+      expect(summary).to.eql({
+        whitelistedModulesFound: [],
+        whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: ['880|github-build>axios'],
+        failedLevelsFound: ['moderate'],
+        advisoriesFound: [880],
+      });
+    });
+  });
+  it('whitelist all vulnerabilities with a whitelisted path', () => {
+    return audit(
+      config({
+        directory: testDir('npm-whitelisted-path'),
+        levels: { moderate: true },
+        'path-whitelist': ['880|axios', '880|github-build>axios'],
+      }),
+      summary => summary
+    ).then(summary => {
+      expect(summary).to.eql({
+        whitelistedModulesFound: [],
+        whitelistedAdvisoriesFound: [],
+        whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: ['880|axios', '880|github-build>axios'],
+        failedLevelsFound: [],
+        advisoriesFound: [],
       });
     });
   });
@@ -173,6 +218,7 @@ describe('npm-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: ['low'],
         advisoriesFound: [722],
       });
@@ -190,6 +236,7 @@ describe('npm-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });

--- a/test/npm-whitelisted-path/package-lock.json
+++ b/test/npm-whitelisted-path/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "audit-ci-npm-whitelisted-path",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "axios": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.15.3.tgz",
+      "integrity": "sha1-LJ1jiy4ZGgjqHWzJiOrda6W9wFM=",
+      "requires": {
+        "follow-redirects": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
+      "integrity": "sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=",
+      "requires": {
+        "debug": "^2.2.0"
+      }
+    },
+    "github-build": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/github-build/-/github-build-1.2.0.tgz",
+      "integrity": "sha512-Iq7NialLYz5yRZDkiX8zaOWd+N3BssJJfUvG7wd8r4MeLCN88SdxEYo2esseMLpLtP4vNXhgamg1eRm7hw59qw==",
+      "requires": {
+        "axios": "0.15.3"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.15.3",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.15.3.tgz",
+          "integrity": "sha1-LJ1jiy4ZGgjqHWzJiOrda6W9wFM=",
+          "requires": {
+            "follow-redirects": "1.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
+          "integrity": "sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=",
+          "requires": {
+            "debug": "^2.2.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    }
+  }
+}

--- a/test/npm-whitelisted-path/package.json
+++ b/test/npm-whitelisted-path/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "audit-ci-npm-whitelisted-path",
+  "dependencies": {
+    "axios": "^0.15.3",
+    "github-build": "^1.2.0"
+  }
+}

--- a/test/yarn-auditer.js
+++ b/test/yarn-auditer.js
@@ -49,6 +49,7 @@ describe('yarn-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: ['critical'],
         advisoriesFound: [663],
       });
@@ -66,6 +67,7 @@ describe('yarn-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -84,6 +86,7 @@ describe('yarn-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: ['high'],
         advisoriesFound: [690],
       });
@@ -102,6 +105,7 @@ describe('yarn-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: ['moderate'],
         advisoriesFound: [658],
       });
@@ -119,6 +123,7 @@ describe('yarn-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -137,6 +142,7 @@ describe('yarn-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [658],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });
@@ -154,6 +160,7 @@ describe('yarn-auditer', function() {
       expect(summary).to.eql({
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
+        whitelistedPathsFound: [],
         whitelistedAdvisoriesNotFound: [659],
         failedLevelsFound: ['moderate'],
         advisoriesFound: [658],
@@ -172,6 +179,7 @@ describe('yarn-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: ['low'],
         advisoriesFound: [722],
       });
@@ -189,6 +197,7 @@ describe('yarn-auditer', function() {
         whitelistedModulesFound: [],
         whitelistedAdvisoriesFound: [],
         whitelistedAdvisoriesNotFound: [],
+        whitelistedPathsFound: [],
         failedLevelsFound: [],
         advisoriesFound: [],
       });


### PR DESCRIPTION
Hello Quinn,

I worked on the `path-whitelist` option to whitelist only specific paths of dependencies to prevent having too broad exceptions. I am working currently on the warning when a whitelisted path is specified in the configuration but does not match an actual path.

In the mean time, what do you think about the feature? Please tell me if the formatting, the tests, or anything else is not correct and should be improved.

Cheers