### PR TITLE
chore: Release 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1330,7 +1330,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Audits npm and yarn projects in CI environments",
   "license": "Apache-2.0",
   "main": "./lib/audit-ci.js",


### PR DESCRIPTION
**Features:**
#104 - Add "path-whitelist" option

**Fixes:**
#108 - Fix `--pass-enoaudit` to not always pass an audit

**Docs:**
#101 - README typo fix for the --report-type
#105 - Aditional examples for path whitelisting