### PR TITLE
pass-enoaudit issue fix, IssueID:107

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -24,7 +24,7 @@ function audit(pm, config, reporter) {
         console.log('RETRY-RETRY');
         return run(attempt + 1);
       }
-      if (config['pass-enoaudit']) {
+      if (config['pass-enoaudit'] && message.includes(RETRY_ERROR_MSG[pm])) {
         console.warn(
           '\x1b[33m%s\x1b[0m',
           `ACTION RECOMMENDED: An audit could not performed due to ${


### PR DESCRIPTION
Fix for 107 Issue

pass-enoaudit flag fails integration if registry does not return ENOAUDIT which is the expected behavior
