### PR TITLE
Add list of advisories to failed summary output

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -37,7 +37,9 @@ function reportAudit(summary, config) {
     // Get the levels that have failed by filtering the keys with true values
     const err = `Failed security audit due to ${summary.failedLevelsFound.join(
       ', '
-    )} vulnerabilities.\nVulnerable advisories are: ${summary.advisoriesFound.join(', ')}`;
+    )} vulnerabilities.\nVulnerable advisories are: ${summary.advisoriesFound.join(
+      ', '
+    )}`;
     throw new Error(err);
   }
   return summary;

--- a/lib/common.js
+++ b/lib/common.js
@@ -37,7 +37,7 @@ function reportAudit(summary, config) {
     // Get the levels that have failed by filtering the keys with true values
     const err = `Failed security audit due to ${summary.failedLevelsFound.join(
       ', '
-    )} vulnerabilities.`;
+    )} vulnerabilities.\nVulnerable advisories are: ${summary.advisoriesFound.join(', ')}`;
     throw new Error(err);
   }
   return summary;

--- a/package-lock.json
+++ b/package-lock.json
@@ -700,10 +700,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "prettier": "1.16.4",
     "pretty-quick": "1.10.0"
   },
+  "resolutions": {
+    "eslint-utils": "^1.4.1"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged",


### PR DESCRIPTION
Our audit-ci was failing with an error like this:

```
yarn run v1.17.3
$ node_modules/audit-ci/bin/audit-ci --config yarn-audit.json
Yarn audit report summary:
{
  "vulnerabilities": {
    "info": 0,
    "low": 0,
    "moderate": 1,
    "high": 15,
    "critical": 0
  },
  "dependencies": 12345,
  "devDependencies": 0,
  "optionalDependencies": 0,
  "totalDependencies": 12345
}
Vulnerable whitelisted advisories found: [__LIST_OF_WHITELISTED_ADVISORIES__].
Failed security audit due to high vulnerabilities.
Exiting...
error Command failed with exit code 1.
```

To find out, which vulnerability was new, I needed to dig down into the list of whilelistes ones and see which advisory is not listed there. BUT I also needed to run `audit-ci` without summary, as otherwise I would not get a list of all vulnerabilities.

The idea with this PR is to add the list of `advisoriesFound` to the output. Just to make it easier and faster to tackle them.

This is the new output:

```
yarn run v1.17.3
$ node_modules/audit-ci/bin/audit-ci --config yarn-audit.json
Yarn audit report summary:
{
  "vulnerabilities": {
    "info": 0,
    "low": 0,
    "moderate": 1,
    "high": 15,
    "critical": 0
  },
  "dependencies": 12345,
  "devDependencies": 0,
  "optionalDependencies": 0,
  "totalDependencies": 12345
}
Vulnerable whitelisted advisories found: [__LIST_OF_WHITELISTED_ADVISORIES__].
Failed security audit due to high vulnerabilities.
Vulnerable advisories are: 1164
Exiting...
error Command failed with exit code 1.
```

*NOTE* There is just a new line after the `Failed security` one.

As there are no tests for the output/error directly, there is no failing one.
Do you want me to add a test for this?