### PR TITLE
Remove duplicate advisories from whitelisted list

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -45,7 +45,9 @@ class Model {
     }
 
     if (this.whitelistedAdvisoryIds.some(a => Number(a) === advisory.id)) {
-      this.whitelistedAdvisoriesFound.push(advisory.id);
+      if (!this.whitelistedAdvisoriesFound.includes(advisory.id)) {
+        this.whitelistedAdvisoriesFound.push(advisory.id);
+      }
       return;
     }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -28,7 +28,9 @@ function reportAudit(summary, config) {
     console.warn('\x1b[33m%s\x1b[0m', msg);
   }
   if (showNotFound && summary.whitelistedAdvisoriesNotFound.length) {
-    const found = summary.whitelistedAdvisoriesNotFound.join(', ');
+    const found = summary.whitelistedAdvisoriesNotFound
+      .sort((a, b) => a - b)
+      .join(', ');
     const msg = `Vulnerable whitelisted advisories not found: ${found}.\nConsider not whitelisting them.`;
     console.warn('\x1b[33m%s\x1b[0m', msg);
   }

--- a/test/Model.js
+++ b/test/Model.js
@@ -295,9 +295,17 @@ describe('Model', () => {
           module_name: 'M_F',
           severity: 'low',
           url: 'https://F',
-          findings: [{ paths: ['M_F'] }],
+          findings: [{ paths: ['M_F_1'] }],
         },
         7: {
+          id: 6,
+          title: 'F',
+          module_name: 'M_F',
+          severity: 'low',
+          url: 'https://F',
+          findings: [{ paths: ['M_F_2'] }],
+        },
+        8: {
           id: 7,
           title: 'G',
           module_name: 'M_G',


### PR DESCRIPTION
This change, removes duplicate whitelisted advisories from the output.

It makes the whitelist more usable, when there are many exactly the same occurrences.

```
...
"whitelistedAdvisoriesFound": [2, 3, 6, 6]
...
```

Turns into
```
...
"whitelistedAdvisoriesFound": [2, 3, 6]
...
```

AND the whitelist summary info is now sorted by ids as well, and not sorted by occurences.