### PR TITLE
Add current audit-ci version to output

### DIFF
--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -3,8 +3,17 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+const childProcess = require('child_process');
 const { runProgram, reportAudit } = require('./common');
 const Model = require('./Model');
+
+function getAuditCiVersion() {
+  const version = childProcess
+    .execSync('npm show audit-ci version')
+    .toString()
+    .replace('\n', '');
+  return version;
+}
 
 function runNpmAudit(config) {
   const { directory, registry, _npm } = config;
@@ -39,10 +48,15 @@ function runNpmAudit(config) {
 }
 
 function printReport(parsedOutput, levels, reportType) {
+  const auditCiVersion = getAuditCiVersion();
+
   function printReportObj(text, obj) {
     console.log('\x1b[36m%s\x1b[0m', text);
     console.log(JSON.stringify(obj, null, 2));
   }
+
+  console.log(`audit-ci version: ${auditCiVersion}`);
+
   switch (reportType) {
     case 'full':
       printReportObj('Yarn audit report JSON:', parsedOutput);

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -24,6 +24,13 @@ function getYarnVersion() {
   return version;
 }
 
+function getAuditCiVersion() {
+  const version = JSON.parse(
+    childProcess.execSync('yarn info audit-ci version --json')
+  ).data;
+  return version;
+}
+
 function yarnSupportsAudit(yarnVersion) {
   return semver.gte(yarnVersion, MINIMUM_YARN_VERSION);
 }
@@ -60,12 +67,15 @@ function audit(config, reporter = reportAudit) {
     const model = new Model(config);
 
     const yarnVersion = getYarnVersion();
+    const auditCiVersion = getAuditCiVersion();
     const isYarnVersionSupported = yarnSupportsAudit(yarnVersion);
     if (!isYarnVersionSupported) {
       throw new Error(
         `Yarn ${yarnVersion} not supported, must be >=${MINIMUM_YARN_VERSION}`
       );
     }
+
+    console.log(`audit-ci version: ${auditCiVersion}`);
 
     if (whitelist.length) {
       console.log(`Modules to whitelist: ${whitelist.join(', ')}.`);


### PR DESCRIPTION
This adds the current `audit-ci` version in npm and yarn output like so:

```
audit-ci version: 2.4.1
Yarn audit report results:
...
```

```
audit-ci version: 2.4.1
NPM audit report results:
...
```