### PR TITLE
fix: Get audit-ci version from package.json

### DIFF
--- a/lib/audit-ci-version.js
+++ b/lib/audit-ci-version.js
@@ -1,0 +1,11 @@
+const { version: auditCiVersion } = require('../package.json');
+
+// I am unsure
+if (!auditCiVersion) {
+  console.log(
+    '\x1b[33m%s\x1b[0m',
+    'Could not identify audit-ci version. Please report this issue to https://github.com/IBM/audit-ci/issues.'
+  );
+}
+
+module.exports = { auditCiVersion };

--- a/lib/audit-ci-version.js
+++ b/lib/audit-ci-version.js
@@ -1,6 +1,5 @@
 const { version: auditCiVersion } = require('../package.json');
 
-// I am unsure
 if (!auditCiVersion) {
   console.log(
     '\x1b[33m%s\x1b[0m',

--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -3,17 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-const childProcess = require('child_process');
+const { auditCiVersion } = require('./audit-ci-version');
 const { runProgram, reportAudit } = require('./common');
 const Model = require('./Model');
-
-function getAuditCiVersion() {
-  const version = childProcess
-    .execSync('npm show audit-ci version')
-    .toString()
-    .replace('\n', '');
-  return version;
-}
 
 function runNpmAudit(config) {
   const { directory, registry, _npm } = config;
@@ -48,8 +40,6 @@ function runNpmAudit(config) {
 }
 
 function printReport(parsedOutput, levels, reportType) {
-  const auditCiVersion = getAuditCiVersion();
-
   function printReportObj(text, obj) {
     console.log('\x1b[36m%s\x1b[0m', text);
     console.log(JSON.stringify(obj, null, 2));

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -5,6 +5,7 @@
  */
 const childProcess = require('child_process');
 const semver = require('semver');
+const { auditCiVersion } = require('./audit-ci-version');
 const { reportAudit, runProgram } = require('./common');
 const Model = require('./Model');
 
@@ -21,13 +22,6 @@ function getYarnVersion() {
     .execSync('yarn -v')
     .toString()
     .replace('\n', '');
-  return version;
-}
-
-function getAuditCiVersion() {
-  const version = JSON.parse(
-    childProcess.execSync('yarn info audit-ci version --json')
-  ).data;
   return version;
 }
 
@@ -67,7 +61,6 @@ function audit(config, reporter = reportAudit) {
     const model = new Model(config);
 
     const yarnVersion = getYarnVersion();
-    const auditCiVersion = getAuditCiVersion();
     const isYarnVersionSupported = yarnSupportsAudit(yarnVersion);
     if (!isYarnVersionSupported) {
       throw new Error(

--- a/test/audit-ci-version.js
+++ b/test/audit-ci-version.js
@@ -1,0 +1,13 @@
+const semver = require('semver');
+const { auditCiVersion } = require('../lib/audit-ci-version');
+
+// To modify what slow times are, need to use
+// function() {} instead of () => {}
+// eslint-disable-next-line func-names
+describe('audit-ci package', function() {
+  it('gets the version of the audit-ci package', () => {
+    const packageVersion = auditCiVersion;
+    semver.valid(packageVersion);
+    semver.gte(packageVersion, '2.4.2');
+  });
+});

--- a/test/audit-ci-version.js
+++ b/test/audit-ci-version.js
@@ -1,10 +1,7 @@
 const semver = require('semver');
 const { auditCiVersion } = require('../lib/audit-ci-version');
 
-// To modify what slow times are, need to use
-// function() {} instead of () => {}
-// eslint-disable-next-line func-names
-describe('audit-ci package', function() {
+describe('audit-ci package', () => {
   it('gets the version of the audit-ci package', () => {
     const packageVersion = auditCiVersion;
     semver.valid(packageVersion);

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -34,8 +34,7 @@ function testDir(s) {
 
 // To modify what slow times are, need to use
 // function() {} instead of () => {}
-// eslint-disable-next-line func-names
-describe('npm-auditer', function() {
+describe('npm-auditer', function testNpmAuditer() {
   this.slow(6000);
   it('prints full report with critical severity', () => {
     return audit(

--- a/test/yarn-auditer.js
+++ b/test/yarn-auditer.js
@@ -33,8 +33,7 @@ function testDir(s) {
 
 // To modify what slow times are, need to use
 // function() {} instead of () => {}
-// eslint-disable-next-line func-names
-describe('yarn-auditer', function() {
+describe('yarn-auditer', function testYarnAuditer() {
   this.slow(3000);
   it('prints full report with critical severity', () => {
     return audit(


### PR DESCRIPTION
Instead of performing a network call to a registry, get the audit-ci version from the package.json

Closes: #119