### PR TITLE
fix(CI): Update CircleCI and Travis-CI build configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12.15
+      - image: circleci/node:lts
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.13
+      - image: circleci/node:12.15
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ jobs:
       - run:
           name: update-npm
           command: 'sudo npm i -g npm@latest'
-      - run:
-          name: install yarn
-          command: 'sudo npm i -g yarn@latest'
 
       # Download and cache dependencies
       - restore_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ node_js:
 before_install:
   # Even though we support Node 6, we still want to use NPM 6
   - npmv=$(echo $(npm -v) | head -c 1); if [ "$npmv" -lt "6" ]; then npm i -g npm; fi
-  # We install Yarn to run unit tests
-  - npm i -g yarn@latest
 
 install:
   - npm ci


### PR DESCRIPTION
- Update CircleCI's Node.js language version to 12.15
- Remove the manual global installation of Yarn in Travis-CI and CircleCI build configs (responsible for https://circleci.com/gh/quinnturner/audit-ci/142)