### PR TITLE
fix(CI): audit-ci checks in CircleCI on PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
       # Have audit-ci run audit-ci to audit itself :)
       - run:
           name: run-audit-ci
-          command: node lib/audit-ci.js -l --config ./audit-ci.json
-
+          # Only have audit-ci checks on pull requests
+          command: if [[ ! -z $CIRCLE_PULL_REQUEST ]] ; then node lib/audit-ci.js -l --config ./audit-ci.json ; fi
       - run:
           name: run-lint
           command: npm run lint


### PR DESCRIPTION
Only support `audit-ci` audit checks on PR builds.
Otherwise, the following scenario can occur:

1. Push a new feature with PR, but master has new vulnerabilities, breaking the PR
2. Create a fix PR with the new advisories, merge PR into master
3. Re-run the feature workflow

The expected behaviour: pass
The current behaviour: fail

This changes the behaviour to be a pass.

Closes #69