### PR TITLE
[BREAKING] Remove deprecated report and summary options

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ before_install:
 |      | --report-type     | Format for the audit report results [_choices_: `important`, `summary`, `full`] (default `important`) |
 |      | --retry-count     | The number of attempts audit-ci calls an unavailable registry before failing (default `5`)            |
 |      | --config          | Path to JSON config file                                                                              |
-| -r   | --report          | [_DEPRECATED_] (Use `--report-type full`) Shows the full audit report (default `false`)               |
-| -s   | --summary         | [_DEPRECATED_] (Use `--report-type summary`) Shows the summary audit report (default `false`)         |
 
 ### (_Optional_) Config file specification
 

--- a/lib/audit-ci.js
+++ b/lib/audit-ci.js
@@ -123,21 +123,7 @@ function mapVulnerabilityLevelInput(config) {
 }
 
 function mapReportTypeInput(config) {
-  const { 'report-type': reportType, report, summary } = config;
-  if (report) {
-    console.warn(
-      '\x1b[33m%s\x1b[0m',
-      "[DEPRECATED] The 'r' and 'report' options have been deprecated and may be removed in the future. Use `--report-type important` [default] to show only relevant information or `--report-type full` to show the full audit report."
-    );
-    return 'full';
-  }
-  if (summary) {
-    console.warn(
-      '\x1b[33m%s\x1b[0m',
-      "[DEPRECATED] The 's' and 'summary' options have been deprecated and may be removed in the future. Use `--report-type important` [default] to show only relevant information or `--report-type summary` to show only the audit metadata."
-    );
-    return 'summary';
-  }
+  const { 'report-type': reportType } = config;
   switch (reportType) {
     case 'full':
     case 'important':


### PR DESCRIPTION
Deprecated one year ago: https://github.com/IBM/audit-ci/pull/74.

In the release notes, will include:

> **[BREAKING]** - The `'r'`, `'report'`, `s`, and `'summary'` options have been removed. Use `--report-type important` _[default]_ to show only relevant information, `--report-type full` to show the full audit report, or `--report-type summary` to only how the summary of the audit report.

Fun fact, it's a complete coincidence that the original PR to deprecate the options was created exactly one year ago today. As we plan on releasing a few breaking changes in `v3`, I thought it would be an appropriate time to deprecate the options. Good timing!