### PR TITLE
chore: Release 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "2.5.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "2.5.1",
+  "version": "3.0.0",
   "description": "Audits npm and yarn projects in CI environments",
   "license": "Apache-2.0",
   "main": "./lib/audit-ci.js",


### PR DESCRIPTION
- #131 **BREAKING**: Drop node 6 support
- #138 **BREAKING**: Remove deprecated report and summary options
- #131 Change prettier settings
- #139 Use async/await syntax
- #139 Possibly fix https://github.com/IBM/audit-ci/issues/139
- #137 Use npmpublish GitHub Action for releases