### PR TITLE
fix: say `NPM` instead of `Yarn` when using npm for full audit report

### DIFF
--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -42,7 +42,7 @@ function printReport(parsedOutput, levels, reportType) {
   };
   switch (reportType) {
     case "full":
-      printReportObj("Yarn audit report JSON:", parsedOutput);
+      printReportObj("NPM audit report JSON:", parsedOutput);
       break;
     case "important": {
       const relevantAdvisories = Object.keys(parsedOutput.advisories).reduce(


### PR DESCRIPTION
Fixes #144 