### PR TITLE
feat(allowlist): Change default to allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 # audit-ci
 
 This module is intended to be consumed by your favourite continuous integration tool to
-halt execution if `npm audit` or `yarn audit` finds vulnerabilities at or above the specified threshold.
+halt execution if `npm audit` or `yarn audit` finds vulnerabilities at or above the specified
+threshold while ignoring allowlisted advisories.
 
 ## Requirements
 
@@ -92,16 +93,21 @@ before_install:
 | -h   | --high            | Prevents integration with high or critical vulnerabilities (default `false`)                          |
 | -c   | --critical        | Prevents integration only with critical vulnerabilities (default `false`)                             |
 | -p   | --package-manager | Choose a package manager [_choices_: `auto`, `npm`, `yarn`] (default `auto`)                          |
-| -a   | --advisories      | Vulnerable advisory ids to whitelist from preventing integration (default `none`)                     |
-| -w   | --whitelist       | Vulnerable modules to whitelist from preventing integration (default `none`)                          |
-|      | --path-whitelist  | Vulnerable module paths to whitelist from preventing integration (default `none`)                     |
+| -a   | --allowlist       | Vulnerable modules, advisories, and paths to allowlist from preventing integration (default `none`)   |
 | -d   | --directory       | The directory containing the package.json to audit (default `./`)                                     |
 |      | --pass-enoaudit   | Pass if no audit is performed due to the registry returning ENOAUDIT (default `false`)                |
+|      | --show-found      | Show whitelisted advisories that are found (default `true`)                                           |
 |      | --show-not-found  | Show whitelisted advisories that are not found (default `true`)                                       |
 |      | --registry        | The registry to resolve packages by name and version (default to unspecified)                         |
 |      | --report-type     | Format for the audit report results [_choices_: `important`, `summary`, `full`] (default `important`) |
 |      | --retry-count     | The number of attempts audit-ci calls an unavailable registry before failing (default `5`)            |
 |      | --config          | Path to JSON config file                                                                              |
+|      | --advisories      | _[DEPRECATED]_ Vulnerable advisory ids to whitelist from preventing integration (default `none`)      |
+| -w   | --whitelist       | _[DEPRECATED]_ Vulnerable modules to whitelist from preventing integration (default `none`)           |
+|      | --path-whitelist  | _[DEPRECATED]_ Vulnerable module paths to whitelist from preventing integration (default `none`)      |
+
+> The options `--advisories`, `--path-whitelist`, `--whitelist`, and `-w` are deprecated in favour of `-a` (alias `--allowlist`)
+> which merge the functionality of all of the deprecated arguments into one argument.
 
 ### (_Optional_) Config file specification
 
@@ -114,15 +120,17 @@ A config file can manage auditing preferences `audit-ci`. The config file's keys
   "moderate": <boolean>, // [Optional] defaults `false`
   "high": <boolean>, // [Optional] defaults `false`
   "critical": <boolean>, // [Optional] defaults `false`
+  "allowlist": <(string | number)[]>, // [Optional] default `[]`
   "report-type": <string>, // [Optional] defaults `important`
   "package-manager": <string>, // [Optional] defaults `"auto"`
-  "advisories": <number[]>, // [Optional] defaults `[]`
-  "whitelist": <string[]>, // [Optional] defaults `[]`
-  "path-whitelist": <string[]>, // [Optional] defaults `[]`
   "pass-enoaudit": <boolean>, // [Optional] defaults `false`
+  "show-found": <boolean>, // [Optional] defaults `true`
   "show-not-found": <boolean>, // [Optional] defaults `true`
   "registry": <string>, // [Optional] defaults `undefined`
-  "retry-count": // [Optional] defaults 5
+  "retry-count": <number>, // [Optional] defaults 5
+  "advisories": <number[]>, // [Deprecated, optional] defaults `[]`
+  "path-whitelist": <string[]>, // [Deprecated, optional] defaults `[]`
+  "whitelist": <string[]> // [Deprecated, optional] defaults `[]`
 }
 ```
 
@@ -139,10 +147,10 @@ Review the examples section for an [example of config file usage](#example-confi
 audit-ci -m
 ```
 
-### Prevents build on any vulnerability except advisory 690 and all of lodash and base64url
+### Prevents build on any vulnerability except advisory 690 and all of lodash and base64url, don't show allowlisted
 
 ```sh
-audit-ci -l -a 690 -w lodash base64url
+audit-ci -l -a 690 lodash base64url --show-found false
 ```
 
 ### Prevents build with critical vulnerabilities showing the full report
@@ -165,9 +173,15 @@ audit-ci --report-type summary
 {
   "low": true,
   "package-manager": "auto",
-  "advisories": [100, 101],
-  "whitelist": ["example1", "example2"],
-  "path-whitelist": ["52|example3", "880|example4", "880|example5>example4"],
+  "allowlist": [
+    100,
+    101,
+    "example1",
+    "example2",
+    "52|example3",
+    "880|example4",
+    "880|example5>example4"
+  ],
   "registry": "https://registry.npmjs.org"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ before_install:
 | -a   | --allowlist       | Vulnerable modules, advisories, and paths to allowlist from preventing integration (default `none`)   |
 | -d   | --directory       | The directory containing the package.json to audit (default `./`)                                     |
 |      | --pass-enoaudit   | Pass if no audit is performed due to the registry returning ENOAUDIT (default `false`)                |
-|      | --show-found      | Show whitelisted advisories that are found (default `true`)                                           |
-|      | --show-not-found  | Show whitelisted advisories that are not found (default `true`)                                       |
+|      | --show-found      | Show allowlisted advisories that are found (default `true`)                                           |
+|      | --show-not-found  | Show allowlisted advisories that are not found (default `true`)                                       |
 |      | --registry        | The registry to resolve packages by name and version (default to unspecified)                         |
 |      | --report-type     | Format for the audit report results [_choices_: `important`, `summary`, `full`] (default `important`) |
 |      | --retry-count     | The number of attempts audit-ci calls an unavailable registry before failing (default `5`)            |

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,4 +1,4 @@
 {
   "low": true,
-  "path-whitelist": []
+  "allowlist": []
 }

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -22,13 +22,11 @@ class Model {
     }
     this.failingSeverities = config.levels;
 
-    this.whitelistedModuleNames = config.whitelist;
-    this.whitelistedPaths = config["path-whitelist"] || [];
-    this.whitelistedAdvisoryIds = config.advisories;
+    this.allowlist = config.allowlist;
 
-    this.whitelistedModulesFound = [];
-    this.whitelistedAdvisoriesFound = [];
-    this.whitelistedPathsFound = [];
+    this.allowlistedModulesFound = [];
+    this.allowlistedAdvisoriesFound = [];
+    this.allowlistedPathsFound = [];
     this.advisoriesFound = [];
   }
 
@@ -37,24 +35,24 @@ class Model {
       return;
     }
 
-    if (this.whitelistedModuleNames.some((m) => m === advisory.module_name)) {
-      if (!this.whitelistedModulesFound.includes(advisory.module_name)) {
-        this.whitelistedModulesFound.push(advisory.module_name);
+    if (this.allowlist.modules.includes(advisory.module_name)) {
+      if (!this.allowlistedModulesFound.includes(advisory.module_name)) {
+        this.allowlistedModulesFound.push(advisory.module_name);
       }
       return;
     }
 
-    if (this.whitelistedAdvisoryIds.some((a) => Number(a) === advisory.id)) {
-      if (!this.whitelistedAdvisoriesFound.includes(advisory.id)) {
-        this.whitelistedAdvisoriesFound.push(advisory.id);
+    if (this.allowlist.advisories.includes(advisory.id)) {
+      if (!this.allowlistedAdvisoriesFound.includes(advisory.id)) {
+        this.allowlistedAdvisoriesFound.push(advisory.id);
       }
       return;
     }
 
     advisory.findings.forEach((finding) =>
       finding.paths.forEach((path) => {
-        if (this.whitelistedPaths.includes(`${advisory.id}|${path}`)) {
-          this.whitelistedPathsFound.push(`${advisory.id}|${path}`);
+        if (this.allowlist.paths.includes(`${advisory.id}|${path}`)) {
+          this.allowlistedPathsFound.push(`${advisory.id}|${path}`);
         }
       })
     );
@@ -62,7 +60,7 @@ class Model {
     if (
       advisory.findings.every((finding) =>
         finding.paths.every((path) =>
-          this.whitelistedPaths.includes(`${advisory.id}|${path}`)
+          this.allowlist.paths.includes(`${advisory.id}|${path}`)
         )
       )
     ) {
@@ -86,17 +84,25 @@ class Model {
 
     const advisoriesFound = this.advisoriesFound.map(advisoryMapper);
 
-    const whitelistedAdvisoriesNotFound = this.whitelistedAdvisoryIds.filter(
-      (id) => !this.whitelistedAdvisoriesFound.includes(id)
+    const allowlistedAdvisoriesNotFound = this.allowlist.advisories.filter(
+      (id) => !this.allowlistedAdvisoriesFound.includes(id)
+    );
+    const allowlistedModulesNotFound = this.allowlist.modules.filter(
+      (id) => !this.allowlistedModulesFound.includes(id)
+    );
+    const allowlistedPathsNotFound = this.allowlist.paths.filter(
+      (id) => !this.allowlistedPathsFound.includes(id)
     );
 
     return {
       advisoriesFound,
       failedLevelsFound,
-      whitelistedAdvisoriesNotFound,
-      whitelistedAdvisoriesFound: this.whitelistedAdvisoriesFound,
-      whitelistedModulesFound: this.whitelistedModulesFound,
-      whitelistedPathsFound: this.whitelistedPathsFound,
+      allowlistedAdvisoriesNotFound,
+      allowlistedModulesNotFound,
+      allowlistedPathsNotFound,
+      allowlistedAdvisoriesFound: this.allowlistedAdvisoriesFound,
+      allowlistedModulesFound: this.allowlistedModulesFound,
+      allowlistedPathsFound: this.allowlistedPathsFound,
     };
   }
 }

--- a/lib/allowlist.js
+++ b/lib/allowlist.js
@@ -1,0 +1,57 @@
+/**
+ * @property {string[]} modules
+ * @property {number[]} advisories
+ * @property {paths[]} paths
+ * @export
+ * @class Allowlist
+ */
+class Allowlist {
+  /**
+   *
+   * @param {(string | number)[]} input the allowlisted module names, advisories, and module paths
+   */
+  constructor(input) {
+    /** @type string[] */
+    this.modules = [];
+    /** @type number[] */
+    this.advisories = [];
+    /** @type string[] */
+    this.paths = [];
+    if (!input) {
+      return;
+    }
+    input.forEach((arg) => {
+      if (typeof arg === "number") {
+        this.advisories.push(arg);
+      } else if (arg.includes(">") || arg.includes("|")) {
+        this.paths.push(arg);
+      } else {
+        this.modules.push(arg);
+      }
+    });
+  }
+
+  static mapConfigToAllowlist(config) {
+    const {
+      allowlist,
+      advisories,
+      whitelist,
+      "path-whitelist": pathWhitelist,
+    } = config;
+    // It's possible someone duplicated the inputs.
+    // The solution is to merge into one array, change to set, and back to array.
+    // This will remove duplicates.
+    const possiblyDuplicated = [
+      ...(allowlist || []),
+      ...(advisories || []),
+      ...(whitelist || []),
+      ...(pathWhitelist || []),
+    ];
+    const set = new Set(possiblyDuplicated);
+    const input = [...set];
+    const obj = new Allowlist(input);
+    return obj;
+  }
+}
+
+module.exports = Allowlist;

--- a/lib/audit-ci.js
+++ b/lib/audit-ci.js
@@ -7,8 +7,9 @@ const fs = require("fs");
 const path = require("path");
 const yargs = require("yargs");
 const audit = require("./audit");
+const Allowlist = require("./allowlist");
 const { printAuditCiVersion } = require("./audit-ci-version");
-const { green, red } = require("./colors");
+const { green, red, yellow } = require("./colors");
 
 printAuditCiVersion();
 
@@ -58,15 +59,10 @@ const { argv } = yargs
       type: "boolean",
     },
     a: {
-      alias: "advisories",
+      alias: "allowlist",
       default: [],
-      describe: "Whitelisted advisory ids",
-      type: "array",
-    },
-    w: {
-      alias: "whitelist",
-      default: [],
-      describe: "Whitelisted module names",
+      describe:
+        "Allowlist module names (example), advisories (123), and module paths (123|example1>example2)",
       type: "array",
     },
     d: {
@@ -75,9 +71,14 @@ const { argv } = yargs
       describe: "The directory containing the package.json to audit",
       type: "string",
     },
+    "show-found": {
+      default: true,
+      describe: "Show allowlisted advisories that are found",
+      type: "boolean",
+    },
     "show-not-found": {
       default: true,
-      describe: "Show whitelisted advisories that are not found",
+      describe: "Show allowlisted advisories that are not found",
       type: "boolean",
     },
     registry: {
@@ -103,9 +104,23 @@ const { argv } = yargs
         "Pass if no audit is performed due to the registry returning ENOAUDIT",
       type: "boolean",
     },
+    advisories: {
+      default: [],
+      describe:
+        "[DEPRECATED, use `-a` or `--allowlist`] Whitelisted advisory ids",
+      type: "array",
+    },
+    w: {
+      alias: "whitelist",
+      default: [],
+      describe:
+        "[DEPRECATED, use `-a` or `--allowlist`] Whitelisted module names",
+      type: "array",
+    },
     "path-whitelist": {
       default: [],
-      describe: "Whitelisted vulnerability paths",
+      describe:
+        "[DEPRECATED, use `-a` or `--allowlist`] Whitelisted vulnerability paths",
       type: "array",
     },
   })
@@ -143,6 +158,31 @@ function mapReportTypeInput(config) {
 
 argv.levels = mapVulnerabilityLevelInput(argv);
 argv["report-type"] = mapReportTypeInput(argv);
+argv.a = Allowlist.mapConfigToAllowlist(argv);
+argv.allowlist = argv.a;
+// Since we are deprecating these options, just set them to `undefined` right away
+if (argv.advisories.length > 0) {
+  console.warn(
+    yellow,
+    "WARNING: Using deprecated `advisories` argument. Use `--allowlist` as a drop-in replacement."
+  );
+}
+argv.advisories = undefined;
+if (argv["path-whitelist"].length > 0) {
+  console.warn(
+    yellow,
+    "WARNING: Using deprecated `path-whitelist` argument. Use `--allowlist` as a drop-in replacement."
+  );
+}
+argv["path-whitelist"] = undefined;
+if (argv.whitelist.length > 0) {
+  console.warn(
+    yellow,
+    "WARNING: Using deprecated `whitelist` argument. Use `--allowlist` as a drop-in replacement."
+  );
+}
+argv.w = undefined;
+argv.whitelist = undefined;
 
 /**
  * @param {'auto' | 'npm' | 'yarn'} pmArg the package manager (including the `auto` option)

--- a/lib/common.js
+++ b/lib/common.js
@@ -10,27 +10,54 @@ const ReadlineTransform = require("readline-transform");
 const { blue, yellow } = require("./colors");
 
 function reportAudit(summary, config) {
-  const { whitelist, "show-not-found": showNotFound } = config;
-  if (whitelist.length) {
-    console.log(blue, `Modules to whitelist: ${whitelist.join(", ")}.`);
+  const { allowlist, "show-not-found": showNotFound, showFound } = config;
+  if (allowlist.modules.length) {
+    console.log(blue, `Modules to allowlist: ${allowlist.modules.join(", ")}.`);
   }
 
-  if (summary.whitelistedModulesFound.length) {
-    const found = summary.whitelistedModulesFound.join(", ");
-    const msg = `Vulnerable whitelisted modules found: ${found}.`;
-    console.warn(yellow, msg);
+  if (showFound) {
+    if (summary.allowlistedModulesFound.length) {
+      const found = summary.allowlistedModulesFound.join(", ");
+      const msg = `Found vulnerable allowlisted modules: ${found}.`;
+      console.warn(yellow, msg);
+    }
+    if (summary.allowlistedAdvisoriesFound.length) {
+      const found = summary.allowlistedAdvisoriesFound.join(", ");
+      const msg = `Found vulnerable allowlisted advisories: ${found}.`;
+      console.warn(yellow, msg);
+    }
   }
-  if (summary.whitelistedAdvisoriesFound.length) {
-    const found = summary.whitelistedAdvisoriesFound.join(", ");
-    const msg = `Vulnerable whitelisted advisories found: ${found}.`;
-    console.warn(yellow, msg);
-  }
-  if (showNotFound && summary.whitelistedAdvisoriesNotFound.length) {
-    const found = summary.whitelistedAdvisoriesNotFound
-      .sort((a, b) => a - b)
-      .join(", ");
-    const msg = `Vulnerable whitelisted advisories not found: ${found}.\nConsider not whitelisting them.`;
-    console.warn(yellow, msg);
+  if (showNotFound) {
+    if (summary.allowlistedModulesNotFound.length) {
+      const found = summary.allowlistedModulesNotFound
+        .sort((a, b) => a - b)
+        .join(", ");
+      const msg =
+        summary.allowlistedModulesNotFound.length === 1
+          ? `Consider not allowlisting module: ${found}.`
+          : `Consider not allowlisting modules: ${found}.`;
+      console.warn(yellow, msg);
+    }
+    if (summary.allowlistedAdvisoriesNotFound.length) {
+      const found = summary.allowlistedAdvisoriesNotFound
+        .sort((a, b) => a - b)
+        .join(", ");
+      const msg =
+        summary.allowlistedAdvisoriesNotFound.length === 1
+          ? `Consider not allowlisting advisory: ${found}.`
+          : `Consider not allowlisting advisories: ${found}.`;
+      console.warn(yellow, msg);
+    }
+    if (summary.allowlistedPathsNotFound.length) {
+      const found = summary.allowlistedPathsNotFound
+        .sort((a, b) => a - b)
+        .join(", ");
+      const msg =
+        summary.allowlistedPathsNotFound.length === 1
+          ? `Consider not allowlisting path: ${found}.`
+          : `Consider not allowlisting paths: ${found}.`;
+      console.warn(yellow, msg);
+    }
   }
 
   if (summary.failedLevelsFound.length) {

--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -75,13 +75,12 @@ function printReport(parsedOutput, levels, reportType) {
 /**
  * Audit your NPM project!
  *
- * @param {{directory: string, report: { full?: boolean, summary?: boolean }, whitelist: string[], advisories: string[], registry: string, levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
+ * @param {{directory: string, report: { full?: boolean, summary?: boolean }, allowlist: object, registry: string, levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
  * `directory`: the directory containing the package.json to audit.
  * `report-type`: [`important`, `summary`, `full`] how the audit report is displayed.
- * `whitelist`: a list of packages that should not break the build if their vulnerability is found.
- * `advisories`: a list of advisory ids that should not break the build if found.
+ * `allowlist`: an object containing a list of modules, advisories, and module paths that should not break the build if their vulnerability is found.
  * `registry`: the registry to resolve packages by name and version.
- * `show-not-found`: show whitelisted advisories that are not found.
+ * `show-not-found`: show allowlisted advisories that are not found.
  * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
  * `_npm`: a path to npm, uses npm from PATH if not specified.
  * @returns {Promise<any>} Returns the audit report summary on resolve, `Error` on rejection.

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -33,25 +33,18 @@ function yarnAuditSupportsRegistry(yarnVersion) {
 /**
  * Audit your Yarn project!
  *
- * @param {{directory: string, report: { full?: boolean, summary?: boolean }, whitelist: string[], advisories: string[], registry: string, levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
+ * @param {{directory: string, report: { full?: boolean, summary?: boolean }, allowlist: object, registry: string, levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
  * `directory`: the directory containing the package.json to audit.
  * `report-type`: [`important`, `summary`, `full`] how the audit report is displayed.
- * `whitelist`: a list of packages that should not break the build if their vulnerability is found.
- * `advisories`: a list of advisory ids that should not break the build if found.
+ * `allowlist`: an object containing a list of modules, advisories, and module paths that should not break the build if their vulnerability is found.
  * `registry`: the registry to resolve packages by name and version.
- * `show-not-found`: show whitelisted advisories that are not found.
+ * `show-not-found`: show allowlisted advisories that are not found.
  * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
  * `_yarn`: a path to yarn, uses yarn from PATH if not specified.
  * @returns {Promise<any>} Returns the audit report summary on resolve, `Error` on rejection.
  */
 async function audit(config, reporter = reportAudit) {
-  const {
-    levels,
-    registry,
-    "report-type": reportType,
-    whitelist,
-    _yarn,
-  } = config;
+  const { levels, registry, "report-type": reportType, _yarn } = config;
   const yarnExec = _yarn || "yarn";
   let missingLockFile = false;
   const model = new Model(config);
@@ -64,9 +57,6 @@ async function audit(config, reporter = reportAudit) {
     );
   }
 
-  if (whitelist.length) {
-    console.log(`Modules to whitelist: ${whitelist.join(", ")}.`);
-  }
   switch (reportType) {
     case "full":
       console.log(blue, "Yarn audit report JSON:");

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,15 @@
+function summaryWithDefault(additions = {}) {
+  const summary = {
+    allowlistedModulesFound: [],
+    allowlistedAdvisoriesFound: [],
+    allowlistedAdvisoriesNotFound: [],
+    allowlistedPathsFound: [],
+    allowlistedModulesNotFound: [],
+    allowlistedPathsNotFound: [],
+    failedLevelsFound: [],
+    advisoriesFound: [],
+  };
+  return { ...summary, ...additions };
+}
+
+module.exports = { summaryWithDefault };

--- a/test/npm-allowlisted-path/package-lock.json
+++ b/test/npm-allowlisted-path/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "audit-ci-npm-whitelisted-path",
+  "name": "audit-ci-npm-allowlisted-path",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/test/npm-allowlisted-path/package.json
+++ b/test/npm-allowlisted-path/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "audit-ci-npm-whitelisted-path",
+  "name": "audit-ci-npm-allowlisted-path",
   "dependencies": {
     "axios": "^0.15.3",
     "github-build": "^1.2.0"

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -6,6 +6,8 @@
 const { expect } = require("chai");
 const path = require("path");
 const audit = require("../lib/audit").bind(null, "npm");
+const Allowlist = require("../lib/allowlist");
+const { summaryWithDefault } = require("./common");
 
 function config(additions) {
   const defaultConfig = {
@@ -16,8 +18,7 @@ function config(additions) {
       critical: false,
     },
     "report-type": "important",
-    advisories: [],
-    whitelist: [],
+    allowlist: new Allowlist(),
     "show-not-found": false,
     "retry-count": 5,
     directory: "./",
@@ -44,14 +45,12 @@ describe("npm-auditer", function testNpmAuditer() {
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: [],
-      failedLevelsFound: ["critical"],
-      advisoriesFound: [663],
-    });
+    expect(summary).to.eql(
+      summaryWithDefault({
+        failedLevelsFound: ["critical"],
+        advisoriesFound: [663],
+      })
+    );
   });
   it("does not report critical severity if it set to false", async () => {
     const summary = await audit(
@@ -61,14 +60,7 @@ describe("npm-auditer", function testNpmAuditer() {
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: [],
-      failedLevelsFound: [],
-      advisoriesFound: [],
-    });
+    expect(summary).to.eql(summaryWithDefault());
   });
   it("reports summary with high severity", async () => {
     const summary = await audit(
@@ -79,14 +71,12 @@ describe("npm-auditer", function testNpmAuditer() {
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: [],
-      failedLevelsFound: ["high"],
-      advisoriesFound: [690],
-    });
+    expect(summary).to.eql(
+      summaryWithDefault({
+        failedLevelsFound: ["high"],
+        advisoriesFound: [690],
+      })
+    );
   });
   it("reports important info with moderate severity", async () => {
     const summary = await audit(
@@ -97,14 +87,12 @@ describe("npm-auditer", function testNpmAuditer() {
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: [],
-      failedLevelsFound: ["moderate"],
-      advisoriesFound: [658],
-    });
+    expect(summary).to.eql(
+      summaryWithDefault({
+        failedLevelsFound: ["moderate"],
+        advisoriesFound: [658],
+      })
+    );
   });
   it("does not report moderate severity if it set to false", async () => {
     const summary = await audit(
@@ -114,86 +102,139 @@ describe("npm-auditer", function testNpmAuditer() {
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: [],
-      failedLevelsFound: [],
-      advisoriesFound: [],
-    });
+    expect(summary).to.eql(summaryWithDefault());
   });
-  it("ignores an advisory if it is whitelisted", async () => {
+  it("[DEPRECATED - advisories] ignores an advisory if it is whitelisted", async () => {
     const summary = await audit(
       config({
         directory: testDir("npm-moderate"),
         levels: { moderate: true },
-        advisories: [658],
+        allowlist: Allowlist.mapConfigToAllowlist({ advisories: [658] }),
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [658],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: [],
-      failedLevelsFound: [],
-      advisoriesFound: [],
-    });
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedAdvisoriesFound: [658],
+      })
+    );
   });
-  it("does not ignore an advisory that is not whitelisted", async () => {
+  it("ignores an advisory if it is allowlisted", async () => {
     const summary = await audit(
       config({
         directory: testDir("npm-moderate"),
         levels: { moderate: true },
-        advisories: [659],
+        allowlist: new Allowlist([658]),
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [659],
-      whitelistedPathsFound: [],
-      failedLevelsFound: ["moderate"],
-      advisoriesFound: [658],
-    });
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedAdvisoriesFound: [658],
+      })
+    );
   });
-  it("reports only vulnerabilities with a not whitelisted path", async () => {
+  it("[DEPRECATED - advisories] does not ignore an advisory that is not whitelisted", async () => {
     const summary = await audit(
       config({
-        directory: testDir("npm-whitelisted-path"),
+        directory: testDir("npm-moderate"),
         levels: { moderate: true },
-        "path-whitelist": ["880|github-build>axios"],
+        allowlist: Allowlist.mapConfigToAllowlist({ advisories: [659] }),
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: ["880|github-build>axios"],
-      failedLevelsFound: ["moderate"],
-      advisoriesFound: [880],
-    });
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedAdvisoriesNotFound: [659],
+        failedLevelsFound: ["moderate"],
+        advisoriesFound: [658],
+      })
+    );
   });
-  it("whitelist all vulnerabilities with a whitelisted path", async () => {
+  it("does not ignore an advisory that is not allowlisted", async () => {
     const summary = await audit(
       config({
-        directory: testDir("npm-whitelisted-path"),
+        directory: testDir("npm-moderate"),
         levels: { moderate: true },
-        "path-whitelist": ["880|axios", "880|github-build>axios"],
+        allowlist: new Allowlist([659]),
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: ["880|axios", "880|github-build>axios"],
-      failedLevelsFound: [],
-      advisoriesFound: [],
-    });
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedAdvisoriesNotFound: [659],
+        failedLevelsFound: ["moderate"],
+        advisoriesFound: [658],
+      })
+    );
+  });
+  it("[DEPRECATED - path-whitelist] reports only vulnerabilities with a not whitelisted path", async () => {
+    const summary = await audit(
+      config({
+        directory: testDir("npm-allowlisted-path"),
+        levels: { moderate: true },
+        allowlist: Allowlist.mapConfigToAllowlist({
+          "path-whitelist": ["880|github-build>axios"],
+        }),
+      }),
+      (_summary) => _summary
+    );
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedPathsFound: ["880|github-build>axios"],
+        failedLevelsFound: ["moderate"],
+        advisoriesFound: [880],
+      })
+    );
+  });
+  it("reports only vulnerabilities with a not allowlisted path", async () => {
+    const summary = await audit(
+      config({
+        directory: testDir("npm-allowlisted-path"),
+        levels: { moderate: true },
+        allowlist: new Allowlist(["880|github-build>axios"]),
+      }),
+      (_summary) => _summary
+    );
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedPathsFound: ["880|github-build>axios"],
+        failedLevelsFound: ["moderate"],
+        advisoriesFound: [880],
+      })
+    );
+  });
+  it("[DEPRECATED - path-whitelist] whitelist all vulnerabilities with a whitelisted path", async () => {
+    const summary = await audit(
+      config({
+        directory: testDir("npm-allowlisted-path"),
+        levels: { moderate: true },
+        allowlist: Allowlist.mapConfigToAllowlist({
+          "path-whitelist": ["880|axios", "880|github-build>axios"],
+        }),
+      }),
+      (_summary) => _summary
+    );
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedPathsFound: ["880|axios", "880|github-build>axios"],
+      })
+    );
+  });
+  it("allowlist all vulnerabilities with a allowlisted path", async () => {
+    const summary = await audit(
+      config({
+        directory: testDir("npm-allowlisted-path"),
+        levels: { moderate: true },
+        allowlist: new Allowlist(["880|axios", "880|github-build>axios"]),
+      }),
+      (_summary) => _summary
+    );
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedPathsFound: ["880|axios", "880|github-build>axios"],
+      })
+    );
   });
   it("reports low severity", async () => {
     const summary = await audit(
@@ -203,14 +244,12 @@ describe("npm-auditer", function testNpmAuditer() {
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: [],
-      failedLevelsFound: ["low"],
-      advisoriesFound: [722],
-    });
+    expect(summary).to.eql(
+      summaryWithDefault({
+        failedLevelsFound: ["low"],
+        advisoriesFound: [786],
+      })
+    );
   });
   it("passes with no vulnerabilities", async () => {
     const summary = await audit(
@@ -220,14 +259,7 @@ describe("npm-auditer", function testNpmAuditer() {
       }),
       (_summary) => _summary
     );
-    expect(summary).to.eql({
-      whitelistedModulesFound: [],
-      whitelistedAdvisoriesFound: [],
-      whitelistedAdvisoriesNotFound: [],
-      whitelistedPathsFound: [],
-      failedLevelsFound: [],
-      advisoriesFound: [],
-    });
+    expect(summary).to.eql(summaryWithDefault());
   });
   it("fails with error code ENOTFOUND on a non-existent site", (done) => {
     audit(

--- a/test/npm-low/package-lock.json
+++ b/test/npm-low/package-lock.json
@@ -3,10 +3,304 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+    "arr-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+      "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+      "requires": {
+        "arr-flatten": "^1.0.1",
+        "array-slice": "^0.2.3"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "array-slice": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      }
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "^2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "kind-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+      "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+      "requires": {
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "lazy-cache": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+      "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+    },
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+    },
+    "micromatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.0.tgz",
+      "integrity": "sha1-lRssRGjF13iFpt9VjqmjOCPn0jg=",
+      "requires": {
+        "arr-diff": "^1.1.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.1",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "normalize-path": "^2.0.0",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+        }
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "^0.1.3"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     }
   }
 }

--- a/test/npm-low/package.json
+++ b/test/npm-low/package.json
@@ -2,6 +2,6 @@
   "name": "audit-ci-npm-low-vulnerability",
   "description": "Test package.json with low vulnerability",
   "dependencies": {
-    "merge": "1.2.0"
+    "micromatch": "2.3.0"
   }
 }

--- a/test/yarn-low/package.json
+++ b/test/yarn-low/package.json
@@ -2,6 +2,6 @@
   "name": "audit-ci-yarn-low-vulnerability",
   "description": "Test package.json with low vulnerability",
   "dependencies": {
-    "merge": "1.2.0"
+    "micromatch": "2.3.0"
   }
 }

--- a/test/yarn-low/yarn.lock
+++ b/test/yarn-low/yarn.lock
@@ -2,7 +2,276 @@
 # yarn lockfile v1
 
 
-merge@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
-  integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=
+arr-diff@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
+  integrity sha1-aHwydYFjWI/vfeezb6vklesaOZo=
+  dependencies:
+    arr-flatten "^1.0.1"
+    array-slice "^0.2.3"
+
+arr-flatten@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+
+array-slice@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
+  integrity sha1-3Tz7gO15c6dRF82sabC5nshhhvU=
+
+array-unique@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+  integrity sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
+
+braces@^1.8.1:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
+  integrity sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=
+  dependencies:
+    expand-range "^1.8.1"
+    preserve "^0.2.0"
+    repeat-element "^1.1.2"
+
+expand-brackets@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
+  integrity sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=
+  dependencies:
+    is-posix-bracket "^0.1.0"
+
+expand-range@^1.8.1:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
+  integrity sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=
+  dependencies:
+    fill-range "^2.1.0"
+
+extglob@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
+  integrity sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=
+  dependencies:
+    is-extglob "^1.0.0"
+
+filename-regex@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+  integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
+
+fill-range@^2.1.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
+  integrity sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==
+  dependencies:
+    is-number "^2.1.0"
+    isobject "^2.0.0"
+    randomatic "^3.0.0"
+    repeat-element "^1.1.2"
+    repeat-string "^1.5.2"
+
+for-in@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+for-own@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=
+  dependencies:
+    for-in "^1.0.1"
+
+glob-base@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
+  integrity sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=
+  dependencies:
+    glob-parent "^2.0.0"
+    is-glob "^2.0.0"
+
+glob-parent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
+  integrity sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=
+  dependencies:
+    is-glob "^2.0.0"
+
+is-buffer@^1.0.2, is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-dotfile@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
+  integrity sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=
+
+is-equal-shallow@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
+  integrity sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=
+  dependencies:
+    is-primitive "^2.0.0"
+
+is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
+
+is-extglob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+  integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
+
+is-glob@^2.0.0, is-glob@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
+  integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
+  dependencies:
+    is-extglob "^1.0.0"
+
+is-number@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  integrity sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
+
+is-posix-bracket@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+  integrity sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=
+
+is-primitive@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+  integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
+
+isarray@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
+  dependencies:
+    isarray "1.0.0"
+
+kind-of@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
+  integrity sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=
+  dependencies:
+    is-buffer "^1.0.2"
+
+kind-of@^3.0.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+lazy-cache@^0.2.3:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-0.2.7.tgz#7feddf2dcb6edb77d11ef1d117ab5ffdf0ab1b65"
+  integrity sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=
+
+math-random@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
+  integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
+
+micromatch@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.0.tgz#951b2c4468c5d77885a6df558ea9a33823e7d238"
+  integrity sha1-lRssRGjF13iFpt9VjqmjOCPn0jg=
+  dependencies:
+    arr-diff "^1.1.0"
+    array-unique "^0.2.1"
+    braces "^1.8.1"
+    expand-brackets "^0.1.4"
+    extglob "^0.3.1"
+    filename-regex "^2.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.1"
+    kind-of "^2.0.1"
+    lazy-cache "^0.2.3"
+    normalize-path "^2.0.0"
+    object.omit "^2.0.0"
+    parse-glob "^3.0.4"
+    regex-cache "^0.4.2"
+
+normalize-path@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
+object.omit@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
+  integrity sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=
+  dependencies:
+    for-own "^0.1.4"
+    is-extendable "^0.1.1"
+
+parse-glob@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
+  integrity sha1-ssN2z7EfNVE7rdFz7wu246OIORw=
+  dependencies:
+    glob-base "^0.3.0"
+    is-dotfile "^1.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.0"
+
+preserve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+  integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
+
+randomatic@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.1.tgz#b776efc59375984e36c537b2f51a1f0aff0da1ed"
+  integrity sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==
+  dependencies:
+    is-number "^4.0.0"
+    kind-of "^6.0.0"
+    math-random "^1.0.1"
+
+regex-cache@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
+  integrity sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==
+  dependencies:
+    is-equal-shallow "^0.1.3"
+
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+repeat-element@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+
+repeat-string@^1.5.2:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=

--- a/test/yarn-none/package.json
+++ b/test/yarn-none/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci-yarn-no-vulnerability",
-  "description": "Test package.json with low vulnerability",
+  "description": "Test package.json with no vulnerability",
   "dependencies": {
     "lodash": "4.17.11"
   }


### PR DESCRIPTION
This PR does quite a few things:

- Supports new argument `allowlist`
merges: advisories, whitelist, and path-whitelist into one argument
- Deprecates advisories, whitelist, and path-whitelist
- Warns the user to update to allowlist
- Adds new argument `show-found`
to allow config for whether to show when found a vuln
- Change low vuln test to have a path
- Adds more warnings to consider not allowlisting
- Adds additional tests

Technically, this is not a breaking change.
This is because we gracefully handle the `-a` flag.
The implementation now has a superset of functionality.

Closes https://github.com/IBM/audit-ci/pull/153
Closes https://github.com/IBM/audit-ci/issues/151
Closes https://github.com/IBM/audit-ci/issues/150