### PR TITLE
chore: Release 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Audits npm and yarn projects in CI environments",
   "license": "Apache-2.0",
   "main": "./lib/audit-ci.js",


### PR DESCRIPTION
- feat(allowlist): Change default to allowlist (#154)
- chore: Add Node 14 to testing matrix (#155)
- chore: Ran npm upgrade (#156)
- chore: Remove /bin (#157)

Note, none of these are technically breaking existing code, so it's a _minor_ update. However, there will be warning for all existing implementations to suggest to migrate towards the new `allowlist` argument.