### PR TITLE
Remove duplicate element of advisoriesFound in summary

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -82,7 +82,9 @@ class Model {
     const failedLevelsFound = [...foundSeverities.values()];
     failedLevelsFound.sort();
 
-    const advisoriesFound = [...new Set(this.advisoriesFound.map(advisoryMapper))];
+    const advisoriesFound = [
+      ...new Set(this.advisoriesFound.map(advisoryMapper)),
+    ];
 
     const allowlistedAdvisoriesNotFound = this.allowlist.advisories.filter(
       (id) => !this.allowlistedAdvisoriesFound.includes(id)

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -82,7 +82,7 @@ class Model {
     const failedLevelsFound = [...foundSeverities.values()];
     failedLevelsFound.sort();
 
-    const advisoriesFound = this.advisoriesFound.map(advisoryMapper);
+    const advisoriesFound = [...new Set(this.advisoriesFound.map(advisoryMapper))];
 
     const allowlistedAdvisoriesNotFound = this.allowlist.advisories.filter(
       (id) => !this.allowlistedAdvisoriesFound.includes(id)

--- a/test/Model.js
+++ b/test/Model.js
@@ -333,7 +333,15 @@ describe("Model", () => {
           module_name: "M_B",
           severity: "critical",
           url: "https://B",
-          findings: [{ paths: ["M_B"] }],
+          findings: [{ paths: ["M_B_1"] }],
+        },
+        3: {
+          id: 2,
+          title: "B",
+          module_name: "M_B",
+          severity: "critical",
+          url: "https://B",
+          findings: [{ paths: ["M_B_2"] }],
         },
       },
     };


### PR DESCRIPTION
This is a followup to #112

Is removes duplicate advisory ids from the summary. 
We cannot go the same route as in #112 as the advisoriesFound are stored as complete hash and not just the advisory.id.

This just removes any duplicate ids from the summary.

Before:
```
Vulnerable advisories are: 1227, 1227
```

After:
```
Vulnerable advisories are: 1227
```