### PR TITLE
chore: Remove SPDX header

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,20 +23,6 @@ The project maintainers use the GitHub reviewer functionality to indicate accept
 
 For a list of the maintainers, see the [MAINTAINERS.md](MAINTAINERS.md) page.
 
-## Legal
-
-Each source file must include a license header for the Apache
-Software License 2.0. Using the SPDX format is the simplest approach.
-e.g.
-
-```
-/*
- * Copyright IBM All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-```
-
 ## Setup
 
 1. `git clone git@github.com:IBM/audit-ci.git`

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -1,8 +1,3 @@
-/*
- * Copyright IBM All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
 const SUPPORTED_SEVERITY_LEVELS = new Set([
   "critical",
   "high",

--- a/lib/audit-ci.js
+++ b/lib/audit-ci.js
@@ -1,9 +1,4 @@
 #!/usr/bin/env node
-/*
- * Copyright IBM All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
 const fs = require("fs");
 const path = require("path");
 const yargs = require("yargs");

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,8 +1,3 @@
-/*
- * Copyright IBM All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
 const { spawn } = require("cross-spawn");
 const eventStream = require("event-stream");
 const JSONStream = require("JSONStream");

--- a/lib/npm-auditer.js
+++ b/lib/npm-auditer.js
@@ -1,8 +1,3 @@
-/*
- * Copyright IBM All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
 const { blue } = require("./colors");
 const { runProgram, reportAudit } = require("./common");
 const Model = require("./Model");

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -1,8 +1,3 @@
-/*
- * Copyright IBM All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
 const childProcess = require("child_process");
 const semver = require("semver");
 const { blue, red, yellow } = require("./colors");

--- a/test/Model.js
+++ b/test/Model.js
@@ -1,8 +1,3 @@
-/*
- * Copyright IBM All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
 const { expect } = require("chai");
 const Model = require("../lib/Model");
 const Allowlist = require("../lib/allowlist");
@@ -53,7 +48,7 @@ describe("Model", () => {
 
     const parsedAuditOutput = {
       advisories: {
-        "663": {
+        663: {
           id: 663,
           title: "Command Injection",
           module_name: "open",

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -1,8 +1,3 @@
-/*
- * Copyright IBM All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
 const { expect } = require("chai");
 const path = require("path");
 const audit = require("../lib/audit").bind(null, "npm");

--- a/test/yarn-auditer.js
+++ b/test/yarn-auditer.js
@@ -1,8 +1,3 @@
-/*
- * Copyright IBM All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
 const { expect } = require("chai");
 const path = require("path");
 const audit = require("../lib/audit").bind(null, "yarn");


### PR DESCRIPTION
The LICENSE is always attached with the project, it's redundant to include the license in the headers. Have had no issues with missing headers in many existing files.