### PR TITLE
chore: Drop support for Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "14"
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "mocha --exit --timeout 40000 --recursive --reporter spec test/*.js"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "dependencies": {
     "JSONStream": "^1.3.5",


### PR DESCRIPTION
Node 8 has been out of maintenance since January 2020: https://nodejs.org/en/about/releases/.

Supporting only Node v10 and higher will allow us to upgrade our dependencies and write more modern code.

Closes: #167