### PR TITLE
fix(circleci): Specify NPM 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - run:
           name: update-npm
-          command: "sudo npm i -g npm@latest"
+          command: "sudo npm i -g npm@6.14.12"
 
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
Fix CircleCI broken build due to incompatibilities with NPM 6 and NPM 7: https://app.circleci.com/pipelines/github/IBM/audit-ci/216/workflows/d9e0450a-7abc-47c4-8ec1-f092ffadc09d/jobs/191