### PR TITLE
chore(release): 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "Audits npm and yarn projects in CI environments",
   "license": "Apache-2.0",
   "main": "./lib/audit-ci.js",
@@ -16,9 +16,9 @@
     "npm",
     "yarn",
     "security",
+    "github",
     "actions",
-    "travis",
-    "travis-ci",
+    "github-actions",
     "circleci"
   ],
   "bin": {


### PR DESCRIPTION
#198 - [BREAKING]: Drop support for Node 8
#198 - Update lots of dependencies, fixing advisories