### PR TITLE
chore(release): 5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Audits npm and yarn projects in CI environments",
   "license": "Apache-2.0",
   "main": "./lib/audit-ci.js",


### PR DESCRIPTION
#196 - Support wildcards in allowlist
#204 - Use array.prototype.flatmap instead of core-js