### PR TITLE
chore(release): 5.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-ci",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Audits npm and yarn projects in CI environments",
   "license": "Apache-2.0",
   "main": "./lib/audit-ci.js",


### PR DESCRIPTION
v5.1.0 does not show up due to an outage of NPM:
https://github.com/IBM/audit-ci/issues/206

This is a re-publish of 5.1.0.