### PR TITLE
Switch identifier to be taken from `github_advisory_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Review the examples section for an [example of config file usage](#example-confi
 npx audit-ci -m
 ```
 
-### Prevents build on any vulnerability except advisory 690 and all of lodash and base64url, don't show allowlisted
+### Prevents build on any vulnerability except advisory "GHSA-38f5-ghc2-fcmv" and all of lodash and base64url, don't show allowlisted
 
 ```sh
 npx audit-ci -l -a "GHSA-38f5-ghc2-fcmv" lodash base64url --show-found false

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ A config file can manage auditing preferences `audit-ci`. The config file's keys
   "moderate": <boolean>, // [Optional] defaults `false`
   "high": <boolean>, // [Optional] defaults `false`
   "critical": <boolean>, // [Optional] defaults `false`
-  "allowlist": <(string | number)[]>, // [Optional] default `[]`
+  "allowlist": <string[]>, // [Optional] default `[]`
   "report-type": <string>, // [Optional] defaults `important`
   "package-manager": <string>, // [Optional] defaults `"auto"`
   "output-format": <string>, // [Optional] defaults `"text"`
@@ -145,7 +145,7 @@ npx audit-ci -m
 ### Prevents build on any vulnerability except advisory 690 and all of lodash and base64url, don't show allowlisted
 
 ```sh
-npx audit-ci -l -a 690 lodash base64url --show-found false
+npx audit-ci -l -a "GHSA-38f5-ghc2-fcmv" lodash base64url --show-found false
 ```
 
 ### Prevents build with critical vulnerabilities showing the full report
@@ -169,13 +169,13 @@ npx audit-ci --report-type summary
   "low": true,
   "package-manager": "auto",
   "allowlist": [
-    100,
-    101,
+    "GHSA-333w-rxj3-f55r",
+    "GHSA-vfvf-mqq8-rwqc",
     "example1",
     "example2",
-    "52|example3",
-    "1038442|example4",
-    "1038442|example5>example4",
+    "GHSA-6354-6mhv-mvv5|example3",
+    "GHSA-42xw-2xvc-qx8m|example4",
+    "GHSA-42xw-2xvc-qx8m|example5>example4",
     "*|example6>*"
   ],
   "registry": "https://registry.npmjs.org"

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -39,9 +39,11 @@ class Model {
       return;
     }
 
-    if (this.allowlist.advisories.includes(advisory.id)) {
-      if (!this.allowlistedAdvisoriesFound.includes(advisory.id)) {
-        this.allowlistedAdvisoriesFound.push(advisory.id);
+    if (this.allowlist.advisories.includes(advisory.github_advisory_id)) {
+      if (
+        !this.allowlistedAdvisoriesFound.includes(advisory.github_advisory_id)
+      ) {
+        this.allowlistedAdvisoriesFound.push(advisory.github_advisory_id);
       }
       return;
     }
@@ -51,7 +53,7 @@ class Model {
 
     advisory.findings
       .flatMap((finding) =>
-        finding.paths.map((path) => `${advisory.id}|${path}`)
+        finding.paths.map((path) => `${advisory.github_advisory_id}|${path}`)
       )
       .filter((path) =>
         this.allowlist.paths.some((allowedPath) =>
@@ -67,7 +69,7 @@ class Model {
     const isAllowListed = advisory.findings.every((finding) =>
       finding.paths.every((path) =>
         this.allowlist.paths.some((allowedPath) =>
-          matchString(allowedPath, `${advisory.id}|${path}`)
+          matchString(allowedPath, `${advisory.github_advisory_id}|${path}`)
         )
       )
     );
@@ -85,7 +87,12 @@ class Model {
     /** NPM 6 */
 
     if (parsedOutput.advisories) {
-      Object.values(parsedOutput.advisories).forEach((a) => this.process(a));
+      Object.values(parsedOutput.advisories).forEach((a) => {
+        console.log(a.url.split("/")[4]);
+        // eslint-disable-next-line no-param-reassign, prefer-destructuring
+        a.github_advisory_id = a.url.split("/")[4];
+        this.process(a);
+      });
       return this.getSummary();
     }
 
@@ -105,6 +112,7 @@ class Model {
           if (!advisoryMap.has(via.source)) {
             advisoryMap.set(via.source, {
               id: via.source,
+              github_advisory_id: via.url.split("/")[4],
               module_name: via.name,
               severity: via.severity,
               url: via.url,
@@ -198,7 +206,7 @@ class Model {
     return this.getSummary();
   }
 
-  getSummary(advisoryMapper = (a) => a.id) {
+  getSummary(advisoryMapper = (a) => a.github_advisory_id) {
     const foundSeverities = new Set();
     this.advisoriesFound.forEach((curr) => foundSeverities.add(curr.severity));
     const failedLevelsFound = Array.from(foundSeverities);

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -1,4 +1,4 @@
-const { matchString } = require("./common");
+const { matchString, gitHubAdvisoryUrlToAdvisoryId } = require("./common");
 
 const SUPPORTED_SEVERITY_LEVELS = new Set([
   "critical",
@@ -89,7 +89,7 @@ class Model {
     if (parsedOutput.advisories) {
       Object.values(parsedOutput.advisories).forEach((a) => {
         // eslint-disable-next-line no-param-reassign, prefer-destructuring
-        a.github_advisory_id = a.url.split("/")[4];
+        a.github_advisory_id = gitHubAdvisoryUrlToAdvisoryId(a.url);
         this.process(a);
       });
       return this.getSummary();
@@ -111,7 +111,7 @@ class Model {
           if (!advisoryMap.has(via.source)) {
             advisoryMap.set(via.source, {
               id: via.source,
-              github_advisory_id: via.url.split("/")[4],
+              github_advisory_id: gitHubAdvisoryUrlToAdvisoryId(via.url),
               module_name: via.name,
               severity: via.severity,
               url: via.url,

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -88,7 +88,6 @@ class Model {
 
     if (parsedOutput.advisories) {
       Object.values(parsedOutput.advisories).forEach((a) => {
-        console.log(a.url.split("/")[4]);
         // eslint-disable-next-line no-param-reassign, prefer-destructuring
         a.github_advisory_id = a.url.split("/")[4];
         this.process(a);

--- a/lib/allowlist.js
+++ b/lib/allowlist.js
@@ -23,7 +23,7 @@ class Allowlist {
     input.forEach((arg) => {
       if (typeof arg === "number") {
         throw new Error(
-          "Unsupported number parameter - Ref https://github.com/IBM/audit-ci/pull/217"
+          "Unsupported number as allowlist. Perform codemod to update config to use GitHub advisory as identifiers: https://github.com/quinnturner/audit-ci-codemod with `npx @quinnturner/audit-ci-codemod`. See also: https://github.com/IBM/audit-ci/pull/217"
         );
       }
 
@@ -32,7 +32,7 @@ class Allowlist {
       } else if (arg.startsWith("GHSA")) {
         this.advisories.push(arg);
       } else {
-      this.modules.push(arg);
+        this.modules.push(arg);
       }
     });
   }

--- a/lib/allowlist.js
+++ b/lib/allowlist.js
@@ -8,12 +8,12 @@
 class Allowlist {
   /**
    *
-   * @param {(string | number)[]} input the allowlisted module names, advisories, and module paths
+   * @param {string[]} input the allowlisted module names, advisories, and module paths
    */
   constructor(input) {
     /** @type string[] */
     this.modules = [];
-    /** @type number[] */
+    /** @type string[] */
     this.advisories = [];
     /** @type string[] */
     this.paths = [];
@@ -22,11 +22,17 @@ class Allowlist {
     }
     input.forEach((arg) => {
       if (typeof arg === "number") {
-        this.advisories.push(arg);
-      } else if (arg.includes(">") || arg.includes("|")) {
+        throw new Error(
+          "Unsupported number parameter - Ref https://github.com/IBM/audit-ci/pull/217"
+        );
+      }
+
+      if (arg.includes(">") || arg.includes("|")) {
         this.paths.push(arg);
+      } else if (arg.startsWith("GHSA")) {
+        this.advisories.push(arg);
       } else {
-        this.modules.push(arg);
+      this.modules.push(arg);
       }
     });
   }

--- a/lib/common.js
+++ b/lib/common.js
@@ -121,8 +121,13 @@ function matchString(template, str) {
     : template === str;
 }
 
+function gitHubAdvisoryUrlToAdvisoryId(url) {
+  return url.split("/")[4];
+}
+
 module.exports = {
   runProgram,
   reportAudit,
   matchString,
+  gitHubAdvisoryUrlToAdvisoryId,
 };

--- a/lib/yarn-auditer.js
+++ b/lib/yarn-auditer.js
@@ -206,7 +206,7 @@ async function audit(config, reporter = reportAudit) {
     );
   }
 
-  const summary = model.getSummary((a) => a.id);
+  const summary = model.getSummary((a) => a.github_advisory_id);
   return reporter(summary, config);
 }
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -10,8 +10,8 @@ function config(additions) {
 describe("Model", () => {
   it("does not support number parameters for Allowlist", () => {
     expect(() => new Model({ allowlist: new Allowlist([123]) })).to.throw(
-      "Unsupported number parameter - Ref https://github.com/IBM/audit-ci/pull/217"
-    )
+      "Unsupported number as allowlist. Perform codemod to update config to use GitHub advisory as identifiers: https://github.com/quinnturner/audit-ci-codemod with `npx @quinnturner/audit-ci-codemod`. See also: https://github.com/IBM/audit-ci/pull/217"
+    );
   });
 
   it("rejects misspelled severity levels", () => {
@@ -54,8 +54,8 @@ describe("Model", () => {
 
     const parsedAuditOutput = {
       advisories: {
-        1004291: {
-          id: 1004291,
+        1066786: {
+          id: 1066786,
           title: "Command Injection",
           module_name: "open",
           severity: "critical",

--- a/test/Model.js
+++ b/test/Model.js
@@ -8,6 +8,12 @@ function config(additions) {
 }
 
 describe("Model", () => {
+  it("does not support number parameters for Allowlist", () => {
+    expect(() => new Model({ allowlist: new Allowlist([123]) })).to.throw(
+      "Unsupported number parameter - Ref https://github.com/IBM/audit-ci/pull/217"
+    )
+  });
+
   it("rejects misspelled severity levels", () => {
     expect(() => new Model(config({ levels: { critical_: true } }))).to.throw(
       "Unsupported severity levels found: critical_"
@@ -48,12 +54,12 @@ describe("Model", () => {
 
     const parsedAuditOutput = {
       advisories: {
-        1066786: {
-          id: 1066786,
+        1004291: {
+          id: 1004291,
           title: "Command Injection",
           module_name: "open",
           severity: "critical",
-          url: "https://npmjs.com/advisories/1066786",
+          url: "https://github.com/advisories/GHSA-28xh-wpgr-7fm8",
           findings: [{ paths: ["open"] }],
         },
       },
@@ -63,7 +69,7 @@ describe("Model", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["critical"],
-        advisoriesFound: [1066786],
+        advisoriesFound: ["GHSA-28xh-wpgr-7fm8"],
       })
     );
   });
@@ -81,7 +87,7 @@ describe("Model", () => {
           title: "A",
           module_name: "M_A",
           severity: "critical",
-          url: "https://A",
+          url: "https://github.com/advisories/GHSA-1",
           findings: [{ paths: ["M_A"] }],
         },
         2: {
@@ -89,7 +95,7 @@ describe("Model", () => {
           title: "B",
           module_name: "M_B",
           severity: "low",
-          url: "https://B",
+          url: "https://github.com/advisories/GHSA-2",
           findings: [{ paths: ["M_B"] }],
         },
         3: {
@@ -97,7 +103,7 @@ describe("Model", () => {
           title: "C",
           module_name: "M_C",
           severity: "moderate",
-          url: "https://C",
+          url: "https://github.com/advisories/GHSA-3",
           findings: [{ paths: ["M_C"] }],
         },
         4: {
@@ -105,7 +111,7 @@ describe("Model", () => {
           title: "D",
           module_name: "M_D",
           severity: "high",
-          url: "https://D",
+          url: "https://github.com/advisories/GHSA-4",
           findings: [{ paths: ["M_D"] }],
         },
         5: {
@@ -113,7 +119,7 @@ describe("Model", () => {
           title: "E",
           module_name: "M_E",
           severity: "critical",
-          url: "https://E",
+          url: "https://github.com/advisories/GHSA-5",
           findings: [{ paths: ["M_E"] }],
         },
         6: {
@@ -121,7 +127,7 @@ describe("Model", () => {
           title: "F",
           module_name: "M_F",
           severity: "low",
-          url: "https://F",
+          url: "https://github.com/advisories/GHSA-6",
           findings: [{ paths: ["M_F"] }],
         },
         7: {
@@ -129,7 +135,7 @@ describe("Model", () => {
           title: "G",
           module_name: "M_G",
           severity: "low",
-          url: "https://G",
+          url: "https://github.com/advisories/GHSA-7",
           findings: [{ paths: ["M_G"] }],
         },
       },
@@ -139,7 +145,7 @@ describe("Model", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["critical", "low"],
-        advisoriesFound: [1, 2, 5, 6, 7],
+        advisoriesFound: ["GHSA-1", "GHSA-2", "GHSA-5", "GHSA-6", "GHSA-7"],
       })
     );
   });
@@ -157,7 +163,7 @@ describe("Model", () => {
           title: "A",
           module_name: "M_A",
           severity: "critical",
-          url: "https://A",
+          url: "https://github.com/advisories/GHSA-1",
           findings: [{ paths: ["M_A"] }],
         },
         2: {
@@ -165,7 +171,7 @@ describe("Model", () => {
           title: "B",
           module_name: "M_B",
           severity: "low",
-          url: "https://B",
+          url: "https://github.com/advisories/GHSA-2",
           findings: [{ paths: ["M_B"] }],
         },
         3: {
@@ -173,7 +179,7 @@ describe("Model", () => {
           title: "C",
           module_name: "M_C",
           severity: "moderate",
-          url: "https://C",
+          url: "https://github.com/advisories/GHSA-3",
           findings: [{ paths: ["M_C"] }],
         },
         4: {
@@ -181,7 +187,7 @@ describe("Model", () => {
           title: "D",
           module_name: "M_D",
           severity: "high",
-          url: "https://D",
+          url: "https://github.com/advisories/GHSA-4",
           findings: [{ paths: ["M_D"] }],
         },
         5: {
@@ -189,7 +195,7 @@ describe("Model", () => {
           title: "E",
           module_name: "M_E",
           severity: "critical",
-          url: "https://E",
+          url: "https://github.com/advisories/GHSA-5",
           findings: [{ paths: ["M_E"] }],
         },
         6: {
@@ -197,7 +203,7 @@ describe("Model", () => {
           title: "F",
           module_name: "M_F",
           severity: "low",
-          url: "https://F",
+          url: "https://github.com/advisories/GHSA-6",
           findings: [{ paths: ["M_F"] }],
         },
         7: {
@@ -205,7 +211,7 @@ describe("Model", () => {
           title: "G",
           module_name: "M_G",
           severity: "low",
-          url: "https://G",
+          url: "https://github.com/advisories/GHSA-7",
           findings: [{ paths: ["M_G"] }],
         },
       },
@@ -216,7 +222,7 @@ describe("Model", () => {
       summaryWithDefault({
         allowlistedModulesFound: ["M_A", "M_D"],
         failedLevelsFound: ["critical", "low", "moderate"],
-        advisoriesFound: [2, 3, 5, 6, 7],
+        advisoriesFound: ["GHSA-2", "GHSA-3", "GHSA-5", "GHSA-6", "GHSA-7"],
       })
     );
   });
@@ -224,7 +230,7 @@ describe("Model", () => {
   it("ignores allowlisted advisory IDs", () => {
     const model = new Model({
       levels: { critical: true, low: true, high: true, moderate: true },
-      allowlist: new Allowlist([2, 3, 6]),
+      allowlist: new Allowlist(["GHSA-2", "GHSA-3", "GHSA-6"]),
     });
 
     const parsedAuditOutput = {
@@ -234,7 +240,7 @@ describe("Model", () => {
           title: "A",
           module_name: "M_A",
           severity: "critical",
-          url: "https://A",
+          url: "https://github.com/advisories/GHSA-1",
           findings: [{ paths: ["M_A"] }],
         },
         2: {
@@ -242,7 +248,7 @@ describe("Model", () => {
           title: "B",
           module_name: "M_B",
           severity: "low",
-          url: "https://B",
+          url: "https://github.com/advisories/GHSA-2",
           findings: [{ paths: ["M_B"] }],
         },
         3: {
@@ -250,7 +256,7 @@ describe("Model", () => {
           title: "C",
           module_name: "M_C",
           severity: "moderate",
-          url: "https://C",
+          url: "https://github.com/advisories/GHSA-3",
           findings: [{ paths: ["M_C"] }],
         },
         4: {
@@ -258,7 +264,7 @@ describe("Model", () => {
           title: "D",
           module_name: "M_D",
           severity: "high",
-          url: "https://D",
+          url: "https://github.com/advisories/GHSA-4",
           findings: [{ paths: ["M_D"] }],
         },
         5: {
@@ -266,7 +272,7 @@ describe("Model", () => {
           title: "E",
           module_name: "M_E",
           severity: "critical",
-          url: "https://E",
+          url: "https://github.com/advisories/GHSA-5",
           findings: [{ paths: ["M_E"] }],
         },
         6: {
@@ -274,7 +280,7 @@ describe("Model", () => {
           title: "F",
           module_name: "M_F",
           severity: "low",
-          url: "https://F",
+          url: "https://github.com/advisories/GHSA-6",
           findings: [{ paths: ["M_F_1"] }],
         },
         7: {
@@ -282,7 +288,7 @@ describe("Model", () => {
           title: "F",
           module_name: "M_F",
           severity: "low",
-          url: "https://F",
+          url: "https://github.com/advisories/GHSA-6",
           findings: [{ paths: ["M_F_2"] }],
         },
         8: {
@@ -290,7 +296,7 @@ describe("Model", () => {
           title: "G",
           module_name: "M_G",
           severity: "low",
-          url: "https://G",
+          url: "https://github.com/advisories/GHSA-7",
           findings: [{ paths: ["M_G"] }],
         },
       },
@@ -299,9 +305,9 @@ describe("Model", () => {
     const summary = model.load(parsedAuditOutput);
     expect(summary).to.eql(
       summaryWithDefault({
-        allowlistedAdvisoriesFound: [2, 3, 6],
+        allowlistedAdvisoriesFound: ["GHSA-2", "GHSA-3", "GHSA-6"],
         failedLevelsFound: ["critical", "high", "low"],
-        advisoriesFound: [1, 4, 5, 7],
+        advisoriesFound: ["GHSA-1", "GHSA-4", "GHSA-5", "GHSA-7"],
       })
     );
   });
@@ -319,7 +325,7 @@ describe("Model", () => {
           title: "A",
           module_name: "M_A",
           severity: "low",
-          url: "https://A",
+          url: "https://github.com/advisories/GHSA-1",
           findings: [{ paths: ["M_A"] }],
         },
         2: {
@@ -327,7 +333,7 @@ describe("Model", () => {
           title: "B",
           module_name: "M_B",
           severity: "critical",
-          url: "https://B",
+          url: "https://github.com/advisories/GHSA-2",
           findings: [{ paths: ["M_B_1"] }],
         },
         3: {
@@ -335,7 +341,7 @@ describe("Model", () => {
           title: "B",
           module_name: "M_B",
           severity: "critical",
-          url: "https://B",
+          url: "https://github.com/advisories/GHSA-2",
           findings: [{ paths: ["M_B_2"] }],
         },
       },
@@ -345,7 +351,7 @@ describe("Model", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["critical", "low"],
-        advisoriesFound: [1, 2],
+        advisoriesFound: ["GHSA-1", "GHSA-2"],
       })
     );
   });
@@ -393,7 +399,7 @@ describe("Model", () => {
               name: "package3",
               dependency: "package3",
               title: "title",
-              url: "https://url",
+              url: "https://github.com/advisories/GHSA-123",
               severity: "moderate",
               range: ">2.1.1 <5.0.1",
             },
@@ -410,7 +416,7 @@ describe("Model", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["moderate"],
-        advisoriesFound: [123],
+        advisoriesFound: ["GHSA-123"],
       })
     );
   });
@@ -458,7 +464,7 @@ describe("Model", () => {
               name: "package3",
               dependency: "package3",
               title: "title",
-              url: "https://url",
+              url: "https://github.com/advisories/GHSA-123",
               severity: "moderate",
               range: ">2.1.1 <5.0.1",
             },
@@ -475,7 +481,7 @@ describe("Model", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["moderate"],
-        advisoriesFound: [123],
+        advisoriesFound: ["GHSA-123"],
       })
     );
   });

--- a/test/common.spec.js
+++ b/test/common.spec.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { matchString } = require("../lib/common");
+const { matchString, gitHubAdvisoryUrlToAdvisoryId } = require("../lib/common");
 
 describe("matchString", () => {
   it("works for various prefixes and suffixes of wildcards", () => {
@@ -7,5 +7,12 @@ describe("matchString", () => {
     expect(matchString("12|axios>*", "12|axios>124")).to.eql(true);
     expect(matchString("*|axios>123", "12|axios>123")).to.eql(true);
     expect(matchString("*|axios>*", "12|axios>123")).to.eql(true);
+  });
+});
+
+describe("gitHubAdvisoryUrlToAdvisoryId", () => {
+  it("converts github-advisory-url to just the advisory-id", () => {
+    expect(gitHubAdvisoryUrlToAdvisoryId("https://github.com/advisories/GHSA-qrpm-p2h7-hrv2")).to.eql("GHSA-qrpm-p2h7-hrv2");
+    expect(gitHubAdvisoryUrlToAdvisoryId("https://github.com/advisories/GHSA-1")).to.eql("GHSA-1");
   });
 });

--- a/test/common.spec.js
+++ b/test/common.spec.js
@@ -12,7 +12,13 @@ describe("matchString", () => {
 
 describe("gitHubAdvisoryUrlToAdvisoryId", () => {
   it("converts github-advisory-url to just the advisory-id", () => {
-    expect(gitHubAdvisoryUrlToAdvisoryId("https://github.com/advisories/GHSA-qrpm-p2h7-hrv2")).to.eql("GHSA-qrpm-p2h7-hrv2");
-    expect(gitHubAdvisoryUrlToAdvisoryId("https://github.com/advisories/GHSA-1")).to.eql("GHSA-1");
+    expect(
+      gitHubAdvisoryUrlToAdvisoryId(
+        "https://github.com/advisories/GHSA-qrpm-p2h7-hrv2"
+      )
+    ).to.eql("GHSA-qrpm-p2h7-hrv2");
+    expect(
+      gitHubAdvisoryUrlToAdvisoryId("https://github.com/advisories/GHSA-1")
+    ).to.eql("GHSA-1");
   });
 });

--- a/test/common.spec.js
+++ b/test/common.spec.js
@@ -3,7 +3,7 @@ const { matchString } = require("../lib/common");
 
 describe("matchString", () => {
   it("works for various prefixes and suffixes of wildcards", () => {
-    expect(matchString("*|axios", "1040655|axios")).to.eql(true);
+    expect(matchString("*|axios", "GHSA-42xw-2xvc-qx8m|axios")).to.eql(true);
     expect(matchString("12|axios>*", "12|axios>124")).to.eql(true);
     expect(matchString("*|axios>123", "12|axios>123")).to.eql(true);
     expect(matchString("*|axios>*", "12|axios>123")).to.eql(true);

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -27,7 +27,7 @@ describe("npm-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["critical"],
-        advisoriesFound: [1066786],
+        advisoriesFound: ["GHSA-28xh-wpgr-7fm8"],
       })
     );
   });
@@ -55,7 +55,7 @@ describe("npm-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["high"],
-        advisoriesFound: [1066151],
+        advisoriesFound: ["GHSA-38f5-ghc2-fcmv"],
       })
     );
   });
@@ -72,7 +72,7 @@ describe("npm-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["moderate"],
-        advisoriesFound: [1066169],
+        advisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
       })
     );
   });
@@ -93,13 +93,13 @@ describe("npm-auditer", () => {
       config({
         directory: testDir("npm-moderate"),
         levels: { moderate: true },
-        allowlist: new Allowlist([1066169]),
+        allowlist: new Allowlist(["GHSA-rvg8-pwq2-xj7q"]),
       }),
       (_summary) => _summary
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        allowlistedAdvisoriesFound: [1066169],
+        allowlistedAdvisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
       })
     );
   });
@@ -109,15 +109,15 @@ describe("npm-auditer", () => {
       config({
         directory: testDir("npm-moderate"),
         levels: { moderate: true },
-        allowlist: new Allowlist([659]),
+        allowlist: new Allowlist(["GHSA-cff4-rrq6-h78w"]),
       }),
       (_summary) => _summary
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        allowlistedAdvisoriesNotFound: [659],
+        allowlistedAdvisoriesNotFound: ["GHSA-cff4-rrq6-h78w"],
         failedLevelsFound: ["moderate"],
-        advisoriesFound: [1066169],
+        advisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
       })
     );
   });
@@ -128,10 +128,10 @@ describe("npm-auditer", () => {
         directory: testDir("npm-allowlisted-path"),
         levels: { moderate: true },
         allowlist: new Allowlist([
-          "1040655|axios",
-          "1040655|github-build>*",
-          "1038442|axios>follow-redirects",
-          "1038442|github-build>axios>follow-redirects",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>*",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
           "*|github-build>axios",
         ]),
       }),
@@ -139,15 +139,15 @@ describe("npm-auditer", () => {
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        advisoriesFound: [1038495, 1038749, 1039327],
+        advisoriesFound: ["GHSA-74fj-2j2h-c42q", "GHSA-cph5-m8f7-6c5x", "GHSA-4w2v-q235-vp99"],
         failedLevelsFound: ["high"],
         allowlistedPathsFound: [
-          "1038442|axios>follow-redirects",
-          "1038442|github-build>axios>follow-redirects",
-          "1038749|github-build>axios",
-          "1039327|github-build>axios",
-          "1040655|axios",
-          "1040655|github-build>axios",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
+          "GHSA-cph5-m8f7-6c5x|github-build>axios",
+          "GHSA-4w2v-q235-vp99|github-build>axios",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>axios",
         ],
       })
     );
@@ -159,16 +159,16 @@ describe("npm-auditer", () => {
         directory: testDir("npm-allowlisted-path"),
         levels: { moderate: true },
         allowlist: new Allowlist([
-          "1038749|axios",
-          "1039327|axios",
-          "1040655|axios",
-          "1038442|axios>follow-redirects",
-          "1038442|github-build>axios>follow-redirects",
-          "1038495|axios>follow-redirects",
-          "1038495|github-build>axios>follow-redirects",
-          "1038749|github-build>axios",
-          "1039327|github-build>axios",
-          "1040655|github-build>axios",
+          "GHSA-cph5-m8f7-6c5x|axios",
+          "GHSA-4w2v-q235-vp99|axios",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|github-build>axios>follow-redirects",
+          "GHSA-cph5-m8f7-6c5x|github-build>axios",
+          "GHSA-4w2v-q235-vp99|github-build>axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>axios",
         ]),
       }),
       (_summary) => _summary
@@ -177,16 +177,16 @@ describe("npm-auditer", () => {
       summaryWithDefault({
         allowlistedAdvisoriesFound: [],
         allowlistedPathsFound: [
-          "1038442|axios>follow-redirects",
-          "1038442|github-build>axios>follow-redirects",
-          "1038495|axios>follow-redirects",
-          "1038495|github-build>axios>follow-redirects",
-          "1038749|axios",
-          "1038749|github-build>axios",
-          "1039327|axios",
-          "1039327|github-build>axios",
-          "1040655|axios",
-          "1040655|github-build>axios",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|github-build>axios>follow-redirects",
+          "GHSA-cph5-m8f7-6c5x|axios",
+          "GHSA-cph5-m8f7-6c5x|github-build>axios",
+          "GHSA-4w2v-q235-vp99|axios",
+          "GHSA-4w2v-q235-vp99|github-build>axios",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>axios",
         ],
       })
     );
@@ -204,16 +204,16 @@ describe("npm-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         allowlistedPathsFound: [
-          "1038442|axios>follow-redirects",
-          "1038442|github-build>axios>follow-redirects",
-          "1038495|axios>follow-redirects",
-          "1038495|github-build>axios>follow-redirects",
-          "1038749|axios",
-          "1038749|github-build>axios",
-          "1039327|axios",
-          "1039327|github-build>axios",
-          "1040655|axios",
-          "1040655|github-build>axios",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|github-build>axios>follow-redirects",
+          "GHSA-cph5-m8f7-6c5x|axios",
+          "GHSA-cph5-m8f7-6c5x|github-build>axios",
+          "GHSA-4w2v-q235-vp99|axios",
+          "GHSA-4w2v-q235-vp99|github-build>axios",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>axios",
         ],
       })
     );
@@ -230,7 +230,7 @@ describe("npm-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["low"],
-        advisoriesFound: [1065151],
+        advisoriesFound: ["GHSA-c6rq-rjc2-86v2"],
       })
     );
   });

--- a/test/npm-auditer.js
+++ b/test/npm-auditer.js
@@ -139,7 +139,11 @@ describe("npm-auditer", () => {
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        advisoriesFound: ["GHSA-74fj-2j2h-c42q", "GHSA-cph5-m8f7-6c5x", "GHSA-4w2v-q235-vp99"],
+        advisoriesFound: [
+          "GHSA-74fj-2j2h-c42q",
+          "GHSA-cph5-m8f7-6c5x",
+          "GHSA-4w2v-q235-vp99",
+        ],
         failedLevelsFound: ["high"],
         allowlistedPathsFound: [
           "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",

--- a/test/npm7-auditer.js
+++ b/test/npm7-auditer.js
@@ -25,7 +25,7 @@ describe("npm7-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["critical"],
-        advisoriesFound: [1066786],
+        advisoriesFound: ["GHSA-28xh-wpgr-7fm8"],
       })
     );
   });
@@ -53,7 +53,7 @@ describe("npm7-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["high"],
-        advisoriesFound: [1066151],
+        advisoriesFound: ["GHSA-38f5-ghc2-fcmv"],
       })
     );
   });
@@ -70,7 +70,7 @@ describe("npm7-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["moderate"],
-        advisoriesFound: [1066169],
+        advisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
       })
     );
   });
@@ -91,13 +91,13 @@ describe("npm7-auditer", () => {
       config({
         directory: testDir("npm-moderate"),
         levels: { moderate: true },
-        allowlist: new Allowlist([1066169]),
+        allowlist: new Allowlist(["GHSA-rvg8-pwq2-xj7q"]),
       }),
       (_summary) => _summary
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        allowlistedAdvisoriesFound: [1066169],
+        allowlistedAdvisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
       })
     );
   });
@@ -107,15 +107,15 @@ describe("npm7-auditer", () => {
       config({
         directory: testDir("npm-moderate"),
         levels: { moderate: true },
-        allowlist: new Allowlist([659]),
+        allowlist: new Allowlist(["GHSA-cff4-rrq6-h78w"]),
       }),
       (_summary) => _summary
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        allowlistedAdvisoriesNotFound: [659],
+        allowlistedAdvisoriesNotFound: ["GHSA-cff4-rrq6-h78w"],
         failedLevelsFound: ["moderate"],
-        advisoriesFound: [1066169],
+        advisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
       })
     );
   });
@@ -126,10 +126,10 @@ describe("npm7-auditer", () => {
         directory: testDir("npm-allowlisted-path"),
         levels: { moderate: true },
         allowlist: new Allowlist([
-          "1040655|axios",
-          "1040655|github-build>*",
-          "1038442|axios>follow-redirects",
-          "1038442|github-build>axios>follow-redirects",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>*",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
           "*|github-build>axios",
         ]),
       }),
@@ -137,15 +137,15 @@ describe("npm7-auditer", () => {
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        advisoriesFound: [1038749, 1039327, 1038495],
+        advisoriesFound: ["GHSA-cph5-m8f7-6c5x", "GHSA-4w2v-q235-vp99", "GHSA-74fj-2j2h-c42q"],
         failedLevelsFound: ["high"],
         allowlistedPathsFound: [
-          "1038749|github-build>axios",
-          "1039327|github-build>axios",
-          "1040655|axios",
-          "1040655|github-build>axios",
-          "1038442|github-build>axios>follow-redirects",
-          "1038442|axios>follow-redirects",
+          "GHSA-cph5-m8f7-6c5x|github-build>axios",
+          "GHSA-4w2v-q235-vp99|github-build>axios",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>axios",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
         ],
       })
     );
@@ -157,16 +157,16 @@ describe("npm7-auditer", () => {
         directory: testDir("npm-allowlisted-path"),
         levels: { moderate: true },
         allowlist: new Allowlist([
-          "1038749|axios",
-          "1039327|axios",
-          "1040655|axios",
-          "1038442|axios>follow-redirects",
-          "1038442|github-build>axios>follow-redirects",
-          "1038495|axios>follow-redirects",
-          "1038495|github-build>axios>follow-redirects",
-          "1038749|github-build>axios",
-          "1039327|github-build>axios",
-          "1040655|github-build>axios",
+          "GHSA-cph5-m8f7-6c5x|axios",
+          "GHSA-4w2v-q235-vp99|axios",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|github-build>axios>follow-redirects",
+          "GHSA-cph5-m8f7-6c5x|github-build>axios",
+          "GHSA-4w2v-q235-vp99|github-build>axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>axios",
         ]),
       }),
       (_summary) => _summary
@@ -174,16 +174,16 @@ describe("npm7-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         allowlistedPathsFound: [
-          "1038749|axios",
-          "1038749|github-build>axios",
-          "1039327|axios",
-          "1039327|github-build>axios",
-          "1040655|axios",
-          "1040655|github-build>axios",
-          "1038442|github-build>axios>follow-redirects",
-          "1038442|axios>follow-redirects",
-          "1038495|github-build>axios>follow-redirects",
-          "1038495|axios>follow-redirects",
+          "GHSA-cph5-m8f7-6c5x|axios",
+          "GHSA-cph5-m8f7-6c5x|github-build>axios",
+          "GHSA-4w2v-q235-vp99|axios",
+          "GHSA-4w2v-q235-vp99|github-build>axios",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>axios",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|github-build>axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|axios>follow-redirects",
         ],
       })
     );
@@ -201,16 +201,16 @@ describe("npm7-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         allowlistedPathsFound: [
-          "1038749|axios",
-          "1038749|github-build>axios",
-          "1039327|axios",
-          "1039327|github-build>axios",
-          "1040655|axios",
-          "1040655|github-build>axios",
-          "1038442|github-build>axios>follow-redirects",
-          "1038442|axios>follow-redirects",
-          "1038495|github-build>axios>follow-redirects",
-          "1038495|axios>follow-redirects",
+          "GHSA-cph5-m8f7-6c5x|axios",
+          "GHSA-cph5-m8f7-6c5x|github-build>axios",
+          "GHSA-4w2v-q235-vp99|axios",
+          "GHSA-4w2v-q235-vp99|github-build>axios",
+          "GHSA-42xw-2xvc-qx8m|axios",
+          "GHSA-42xw-2xvc-qx8m|github-build>axios",
+          "GHSA-pw2r-vq6v-hr8c|github-build>axios>follow-redirects",
+          "GHSA-pw2r-vq6v-hr8c|axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|github-build>axios>follow-redirects",
+          "GHSA-74fj-2j2h-c42q|axios>follow-redirects",
         ],
       })
     );
@@ -227,7 +227,7 @@ describe("npm7-auditer", () => {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["low"],
-        advisoriesFound: [1065151],
+        advisoriesFound: ["GHSA-c6rq-rjc2-86v2"],
       })
     );
   });

--- a/test/npm7-auditer.js
+++ b/test/npm7-auditer.js
@@ -137,7 +137,11 @@ describe("npm7-auditer", () => {
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        advisoriesFound: ["GHSA-cph5-m8f7-6c5x", "GHSA-4w2v-q235-vp99", "GHSA-74fj-2j2h-c42q"],
+        advisoriesFound: [
+          "GHSA-cph5-m8f7-6c5x",
+          "GHSA-4w2v-q235-vp99",
+          "GHSA-74fj-2j2h-c42q",
+        ],
         failedLevelsFound: ["high"],
         allowlistedPathsFound: [
           "GHSA-cph5-m8f7-6c5x|github-build>axios",

--- a/test/yarn-auditer.js
+++ b/test/yarn-auditer.js
@@ -51,7 +51,7 @@ describe("yarn-auditer", function testYarnAuditer() {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["critical"],
-        advisoriesFound: [1066786],
+        advisoriesFound: ["GHSA-28xh-wpgr-7fm8"],
       })
     );
   });
@@ -77,7 +77,7 @@ describe("yarn-auditer", function testYarnAuditer() {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["high"],
-        advisoriesFound: [1066151],
+        advisoriesFound: ["GHSA-38f5-ghc2-fcmv"],
       })
     );
   });
@@ -93,7 +93,7 @@ describe("yarn-auditer", function testYarnAuditer() {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["moderate"],
-        advisoriesFound: [1066169],
+        advisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
       })
     );
   });
@@ -112,13 +112,13 @@ describe("yarn-auditer", function testYarnAuditer() {
       config({
         directory: testDir("yarn-moderate"),
         levels: { moderate: true },
-        allowlist: new Allowlist([1066169]),
+        allowlist: new Allowlist(["GHSA-rvg8-pwq2-xj7q"]),
       }),
       (_summary) => _summary
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        allowlistedAdvisoriesFound: [1066169],
+        allowlistedAdvisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
       })
     );
   });
@@ -127,15 +127,15 @@ describe("yarn-auditer", function testYarnAuditer() {
       config({
         directory: testDir("yarn-moderate"),
         levels: { moderate: true },
-        allowlist: new Allowlist([659]),
+        allowlist: new Allowlist(["GHSA-cff4-rrq6-h78w"]),
       }),
       (_summary) => _summary
     );
     expect(summary).to.eql(
       summaryWithDefault({
-        allowlistedAdvisoriesNotFound: [659],
+        allowlistedAdvisoriesNotFound: ["GHSA-cff4-rrq6-h78w"],
         failedLevelsFound: ["moderate"],
-        advisoriesFound: [1066169],
+        advisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
       })
     );
   });
@@ -150,7 +150,7 @@ describe("yarn-auditer", function testYarnAuditer() {
     expect(summary).to.eql(
       summaryWithDefault({
         failedLevelsFound: ["low"],
-        advisoriesFound: [1065151],
+        advisoriesFound: ["GHSA-c6rq-rjc2-86v2"],
       })
     );
   });
@@ -187,7 +187,7 @@ describe("yarn-auditer", function testYarnAuditer() {
       expect(summary).to.eql(
         summaryWithDefault({
           failedLevelsFound: ["moderate"],
-          advisoriesFound: [1066169],
+          advisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
         })
       );
     }
@@ -212,13 +212,13 @@ describe("yarn-auditer", function testYarnAuditer() {
         config({
           directory: testDir("yarn-berry-moderate"),
           levels: { moderate: true },
-          allowlist: new Allowlist([1066169]),
+          allowlist: new Allowlist(["GHSA-rvg8-pwq2-xj7q"]),
         }),
         (_summary) => _summary
       );
       expect(summary).to.eql(
         summaryWithDefault({
-          allowlistedAdvisoriesFound: [1066169],
+          allowlistedAdvisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
         })
       );
     }

--- a/test/yarn-config-file/audit-ci.json
+++ b/test/yarn-config-file/audit-ci.json
@@ -1,6 +1,6 @@
 {
   "low": "true",
   "advisories": [
-    1066786
+    "GHSA-28xh-wpgr-7fm8"
   ]
 }

--- a/test/yarn-config-file/audit-ci.json
+++ b/test/yarn-config-file/audit-ci.json
@@ -1,6 +1,5 @@
 {
   "low": "true",
   "advisories": [
-    "GHSA-28xh-wpgr-7fm8"
   ]
 }


### PR DESCRIPTION
**Background:**
Two of our allowlist entries changed their npm-number 4 times in the last 48 hours!!!

This is a **BREAKING CHANGE** as the identifier that is used to identify advisories is being changed from numerical npm-identifier to string github-identifiers e.g. `GHSA-rvg8-pwq2-xj7q`

Making this backward compatible is for couple of reasons not good:
1. npm-identifiers are **NOT** constant
2. npmjs.com does not use the identifiers in the `url` attribute of the json response
3. mix of numerical and string identifiers would need to be supported (in my opinion)
4. makes this package very complex

~~NOTE: I bases this change not on `IBM:main` but `quinnturner:node-12` branch so it has some changes not related to the pull-request in it. That was needed to make tests~~ 🟢  ~~which they are now~~ 😄