### PR TITLE
Recommend JSONC instead of CLI args

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run:
           name: run-audit-ci
           # Only have audit-ci checks on pull requests
-          command: if [[ ! -z $CIRCLE_PULL_REQUEST ]]; then node lib/audit-ci.js --config ./audit-ci.json; fi
+          command: if [[ ! -z $CIRCLE_PULL_REQUEST ]]; then node lib/audit-ci.js --config ./audit-ci.jsonc; fi
       - run:
           name: run-lint
           command: npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ cache: npm
 
 script:
   # Have audit-ci run audit-ci to audit itself :)
-  - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then node lib/audit-ci.js --config ./audit-ci.json; fi
+  - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then node lib/audit-ci.js --config ./audit-ci.jsonc; fi
   - npm run lint
   - npm run test

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For simplicity, the examples use `npx` and do not use a config file.
 steps:
   - uses: actions/checkout@v2
   - name: Audit for vulnerabilities
-    run: npx audit-ci --moderate
+    run: npx audit-ci --config ./audit-ci.jsonc
 ```
 
 ### CircleCI
@@ -59,7 +59,7 @@ steps:
   # the risk of executing a script from a compromised NPM package.
   - run:
       name: run-audit-ci
-      command: npx audit-ci --moderate
+      command: npx audit-ci --config ./audit-ci.jsonc
       # If you use a pull-request-only workflow,
       # it's better to not run audit-ci on `main` and only run it on pull requests.
       # For more info: https://github.com/IBM/audit-ci/issues/69
@@ -83,7 +83,7 @@ For `Travis-CI` not using PR builds:
 
 ```yml
 scripts:
-  - npx audit-ci --moderate
+  - npx audit-ci --config ./audit-ci.jsonc
 ```
 
 ## Options
@@ -164,7 +164,7 @@ npx audit-ci --report-type summary
 
 ### Example config file and different directory usage
 
-#### test/npm-config-file/audit-ci.json
+#### test/npm-config-file/audit-ci.jsonc
 
 ```json
 {
@@ -185,7 +185,7 @@ npx audit-ci --report-type summary
 ```
 
 ```sh
-npx audit-ci --directory test/npm-config-file --config test/npm-config-file/audit-ci.json
+npx audit-ci --directory test/npm-config-file --config test/npm-config-file/audit-ci.jsonc
 ```
 
 ## Codemod
@@ -206,7 +206,7 @@ $ npx @quinnturner/audit-ci-codemod
 Need to install the following packages:
   @quinnturner/audit-ci-codemod
 Ok to proceed? (y) y
-? What's the path for the audit-ci config? audit-ci.json
+? What's the path for the audit-ci config? audit-ci.jsonc
 Performed migration from advisories, whitelist, and path-whitelist to allowlist
 Performed migration from NPM advisories to GitHub advisories
 ```

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,4 +1,0 @@
-{
-  "low": true,
-  "allowlist": []
-}

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,5 @@
+{
+  // audit-ci supports reading JSON, JSONC, and JSON5 config files.
+  "low": true,
+  "allowlist": []
+}

--- a/lib/audit-ci.js
+++ b/lib/audit-ci.js
@@ -11,7 +11,7 @@ const { mapVulnerabilityLevelInput } = require("./map-vulnerability");
 
 const { argv } = yargs
   .config("config", (configPath) =>
-    // Supports JSON & JSON5
+    // Supports JSON, JSONC, & JSON5
     jju.parse(fs.readFileSync(configPath, "utf-8"))
   )
   .options({

--- a/test/npm-config-file/audit-ci-with-comment.jsonc
+++ b/test/npm-config-file/audit-ci-with-comment.jsonc
@@ -1,0 +1,8 @@
+{
+  // JSON comment
+  "low": "true",
+  "allowlist": [
+    /** JSON comment */
+    "open"
+  ]
+}


### PR DESCRIPTION
- NPM now supports flags like --moderate.
Therefore, audit-ci's main differentiator is to use a config file
with allowlist.
Currently, our documentation pushes towards using the CLI.
Instead, prefer to show examples using a config file.
- Convert audit-ci.json -> audit-ci.jsonc