### PR TITLE
Type improvements and better functional structuring

### DIFF
--- a/lib/audit-ci.ts
+++ b/lib/audit-ci.ts
@@ -4,14 +4,15 @@ import { green, red } from "./colors";
 import { runYargs } from "./config";
 
 export async function runAuditCi() {
-  const argv = await runYargs();
+  const auditCiConfig = await runYargs();
 
-  printAuditCiVersion(argv.o);
+  const { "package-manager": packageManager, "output-format": outputFormat } =
+    auditCiConfig;
 
-  const { p: packageManager, o: outputFormat } = argv;
+  printAuditCiVersion(outputFormat);
 
   try {
-    await audit(packageManager, argv);
+    await audit(auditCiConfig);
     if (outputFormat === "text") {
       console.log(green, `Passed ${packageManager} security audit.`);
     }

--- a/lib/audit-ci.ts
+++ b/lib/audit-ci.ts
@@ -4,7 +4,7 @@ import { printAuditCiVersion } from "./audit-ci-version";
 import { green, red } from "./colors";
 import { runYargs } from "./config";
 
-async function main() {
+async function runAuditCi() {
   const argv = await runYargs();
 
   printAuditCiVersion(argv.o);
@@ -26,4 +26,4 @@ async function main() {
   }
 }
 
-main();
+runAuditCi();

--- a/lib/audit-ci.ts
+++ b/lib/audit-ci.ts
@@ -1,10 +1,9 @@
-#!/usr/bin/env node
 import audit from "./audit";
 import { printAuditCiVersion } from "./audit-ci-version";
 import { green, red } from "./colors";
 import { runYargs } from "./config";
 
-async function runAuditCi() {
+export async function runAuditCi() {
   const argv = await runYargs();
 
   printAuditCiVersion(argv.o);
@@ -25,5 +24,3 @@ async function runAuditCi() {
     process.exitCode = 1;
   }
 }
-
-runAuditCi();

--- a/lib/bin.ts
+++ b/lib/bin.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runAuditCi } from "./audit-ci";
+
+runAuditCi();

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -25,7 +25,7 @@ export function reportAudit(summary: Summary, config: AuditCiConfig) {
     allowlist,
     "show-not-found": showNotFound,
     "show-found": showFound,
-    o,
+    "output-format": outputFormat,
   } = config;
   const {
     allowlistedModulesFound,
@@ -38,7 +38,7 @@ export function reportAudit(summary: Summary, config: AuditCiConfig) {
     advisoryPathsFound,
   } = summary;
 
-  if (o === "text") {
+  if (outputFormat === "text") {
     if (allowlist.modules.length > 0) {
       console.log(
         blue,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -94,6 +94,8 @@ type ComplexConfig = Omit<AuditCiPreprocessedConfig, "allowlist" | "a"> & {
   levels: { [K in keyof VulnerabilityLevels]: VulnerabilityLevels[K] };
   /** A path to yarn, uses yarn from PATH if not specified (internal use only) */
   _yarn?: string;
+  /** A path to npm, uses npm from PATH if not specified (internal use only) */
+  _npm?: string;
 };
 export type AuditCiConfig = { [K in keyof ComplexConfig]: ComplexConfig[K] };
 
@@ -111,7 +113,7 @@ function getPackageManagerType(
     case "yarn":
       return pmArgument;
     case "auto": {
-      const getPath = (file) => path.resolve(directory, file);
+      const getPath = (file: string) => path.resolve(directory, file);
       const packageLockExists = existsSync(getPath("package-lock.json"));
       if (packageLockExists) return "npm";
       const shrinkwrapExists = existsSync(getPath("npm-shrinkwrap.json"));

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -104,7 +104,7 @@ export type AuditCiConfig = { [K in keyof ComplexConfig]: ComplexConfig[K] };
  * @param directory the directory where the package manager files exist
  * @returns the non-`auto` package manager
  */
-function getPackageManagerType(
+function resolvePackageManagerType(
   pmArgument: "auto" | "npm" | "yarn",
   directory: string
 ): "npm" | "yarn" {
@@ -243,7 +243,7 @@ export async function runYargs(): Promise<AuditCiConfig> {
 
   const { l, m, h, c, p, d } = awaitedArgv;
 
-  const packageManager = getPackageManagerType(p, d);
+  const packageManager = resolvePackageManagerType(p, d);
 
   const result: AuditCiConfig = {
     ...awaitedArgv,

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -14,7 +14,8 @@ const SUPPORTED_SEVERITY_LEVELS = new Set([
   "low",
 ]);
 
-const prependPath = (newItem, currentPath) => `${newItem}>${currentPath}`;
+const prependPath = (newItem: string, currentPath: string) =>
+  `${newItem}>${currentPath}`;
 
 export interface Summary {
   advisoriesFound: string[];

--- a/lib/npm-auditer.ts
+++ b/lib/npm-auditer.ts
@@ -3,8 +3,13 @@ import { reportAudit, runProgram } from "./common";
 import { AuditCiConfig } from "./config";
 import Model from "./model";
 
-async function runNpmAudit(config) {
-  const { directory, registry, _npm } = config;
+async function runNpmAudit(config: AuditCiConfig) {
+  const {
+    directory,
+    registry,
+    _npm,
+    "skip-dev": skipDevelopmentDependencies,
+  } = config;
   const npmExec = _npm || "npm";
 
   let stdoutBuffer: any = {};
@@ -21,7 +26,7 @@ async function runNpmAudit(config) {
   if (registry) {
     arguments_.push("--registry", registry);
   }
-  if (config["skip-dev"]) {
+  if (skipDevelopmentDependencies) {
     arguments_.push("--production");
   }
   const options = { cwd: directory };
@@ -34,13 +39,12 @@ async function runNpmAudit(config) {
   return stdoutBuffer;
 }
 
-/**
- * @param {*} parsedOutput
- * @param {*} levels
- * @param {"full" | "important" | "summary"} reportType
- * @param {"text" | "json"} outputFormat
- */
-function printReport(parsedOutput, levels, reportType, outputFormat) {
+function printReport(
+  parsedOutput: any,
+  levels: any,
+  reportType: "full" | "important" | "summary",
+  outputFormat: "text" | "json"
+) {
   const printReportObject = (text, object) => {
     if (outputFormat === "text") {
       console.log(blue, text);
@@ -93,18 +97,9 @@ export function report(parsedOutput, config: AuditCiConfig, reporter) {
 /**
  * Audit your NPM project!
  *
- * @param {{directory: string, report: { full?: boolean, summary?: boolean }, allowlist: object, registry: string, levels: { low: boolean, moderate: boolean, high: boolean, critical: boolean }}} config
- * `directory`: the directory containing the package.json to audit.
- * `report-type`: [`important`, `summary`, `full`] how the audit report is displayed.
- * `allowlist`: an object containing a list of modules, advisories, and module paths that should not break the build if their vulnerability is found.
- * `registry`: the registry to resolve packages by name and version.
- * `show-not-found`: show allowlisted advisories that are not found.
- * `levels`: the vulnerability levels to fail on, if `moderate` is set `true`, `high` and `critical` should be as well.
- * `skip-dev`: skip devDependencies, defaults to false
- * `_npm`: a path to npm, uses npm from PATH if not specified.
- * @returns {Promise<any>} Returns the audit report summary on resolve, `Error` on rejection.
+ * @returns Returns the audit report summary on resolve, `Error` on rejection.
  */
-export async function audit(config, reporter = reportAudit) {
+export async function audit(config: AuditCiConfig, reporter = reportAudit) {
   const parsedOutput = await runNpmAudit(config);
   if (parsedOutput.error) {
     const { code, summary } = parsedOutput.error;

--- a/lib/npm-auditer.ts
+++ b/lib/npm-auditer.ts
@@ -88,7 +88,12 @@ function printReport(
 }
 
 export function report(parsedOutput, config: AuditCiConfig, reporter) {
-  printReport(parsedOutput, config.levels, config["report-type"], config.o);
+  const {
+    levels,
+    "report-type": reportType,
+    "output-format": outputFormat,
+  } = config;
+  printReport(parsedOutput, levels, reportType, outputFormat);
   const model = new Model(config);
   const summary = model.load(parsedOutput);
   return reporter(summary, config, parsedOutput);

--- a/lib/yarn-auditer.ts
+++ b/lib/yarn-auditer.ts
@@ -58,7 +58,7 @@ export async function audit(
     registry,
     "report-type": reportType,
     "skip-dev": skipDevelopmentDependencies,
-    o: outputFormat,
+    "output-format": outputFormat,
     _yarn,
     directory,
   } = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "audit-ci": "dist/bin.js"
       },
       "devDependencies": {
+        "@types/chai": "^4.3.0",
         "@types/cross-spawn": "^6.0.2",
         "@types/event-stream": "^4.0.0",
         "@types/jju": "^1.4.2",
@@ -206,6 +207,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+      "dev": true
     },
     "node_modules/@types/cross-spawn": {
       "version": "6.0.2",
@@ -4032,6 +4039,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@types/chai": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+      "dev": true
     },
     "@types/cross-spawn": {
       "version": "6.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "yargs": "^17.0.0"
       },
       "bin": {
-        "audit-ci": "dist/audit-ci.js"
+        "audit-ci": "dist/bin.js"
       },
       "devDependencies": {
         "@types/cross-spawn": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "circleci"
   ],
   "bin": {
-    "audit-ci": "./dist/audit-ci.js"
+    "audit-ci": "./dist/bin.js"
   },
   "files": [
     "dist/*",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "yargs": "^17.0.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.3.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/event-stream": "^4.0.0",
     "@types/jju": "^1.4.2",

--- a/test/yarn-auditer.spec.js
+++ b/test/yarn-auditer.spec.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 const childProcess = require("child_process");
 const path = require("path");
 const semver = require("semver");
-const audit = require("../dist/audit").default.bind(undefined, "yarn");
+const { default: audit } = require("../dist/audit");
 const { default: Allowlist } = require("../dist/allowlist");
 const { summaryWithDefault } = require("./common");
 


### PR DESCRIPTION
- Simplifies the `AuditCiConfig` type
- Creates `dist/bin.js` instead of reusing `dist/audit-ci.js`; prep for programmatic usage
- Add `@types/chai`