### PR TITLE
feat: PNPM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # audit-ci
 
 This module is intended to be consumed by your favourite continuous integration tool to
-halt execution if `npm audit` or `yarn audit` finds vulnerabilities at or above the specified
+halt execution if `npm audit`, `yarn audit` or `pnpm audit` finds vulnerabilities at or above the specified
 threshold while ignoring allowlisted advisories.
 
 > Note: Use our [codemod](#codemod) to update to [`audit-ci` v6.0.0](https://github.com/IBM/audit-ci/releases/tag/v6.0.0)
@@ -13,20 +13,24 @@ threshold while ignoring allowlisted advisories.
 
 - Node >=12.9.0 (Yarn Berry requires Node >=12.13.0)
 - _(Optional)_ Yarn ^1.12.3 || Yarn >=2.4.0
+- _(Optional)_ PNPM >=4.3.0
 
 ## Set up
 
 Install `audit-ci` during your CI environment using `npx` or as a devDependency.
 
-> `npx audit-ci --config ./audit-ci.jsonc`
+```sh
+npx audit-ci --config ./audit-ci.jsonc
+```
 
-Alternatively, for the devDependency approach with NPM:
+Alternatively, `audit-ci` can be installed as a devDependency:
 
-> `npm install --save-dev audit-ci`
-
-or, using `yarn`:
-
-> `yarn add -D audit-ci`
+```sh
+# Use the option for your project's package manager
+npm install -D audit-ci
+yarn add -D audit-ci
+pnpm install -D audit-ci
+```
 
 The next section gives examples using `audit-ci` in various CI environments.
 It assumes that moderate, high, and critical severity vulnerabilities prevent build continuation.
@@ -110,7 +114,7 @@ scripts:
 | -m   | --moderate        | Prevents integration with moderate or higher vulnerabilities (default `false`)                        |
 | -h   | --high            | Prevents integration with high or critical vulnerabilities (default `false`)                          |
 | -c   | --critical        | Prevents integration only with critical vulnerabilities (default `false`)                             |
-| -p   | --package-manager | Choose a package manager [_choices_: `auto`, `npm`, `yarn`] (default `auto`)                          |
+| -p   | --package-manager | Choose a package manager [_choices_: `auto`, `npm`, `yarn`, `pnpm`] (default `auto`)                  |
 | -a   | --allowlist       | Vulnerable modules, advisories, and paths to allowlist from preventing integration (default `none`)   |
 | -o   | --output-format   | The format of the output of audit-ci [_choices_: `text`, `json`] (default `text`)                     |
 | -d   | --directory       | The directory containing the package.json to audit (default `./`)                                     |

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -2,6 +2,7 @@ import { yellow } from "./colors";
 import { AuditCiConfig } from "./config";
 import { Summary } from "./model";
 import * as npmAuditer from "./npm-auditer";
+import * as pnpmAuditer from "./pnpm-auditer";
 import * as yarnAuditer from "./yarn-auditer";
 
 const PARTIAL_RETRY_ERROR_MSG = {
@@ -14,6 +15,19 @@ const PARTIAL_RETRY_ERROR_MSG = {
   yarn: "503 Service Unavailable",
 };
 
+function getAuditor(packageManager: "npm" | "yarn" | "pnpm") {
+  switch (packageManager) {
+    case "yarn":
+      return yarnAuditer;
+    case "npm":
+      return npmAuditer;
+    case "pnpm":
+      return pnpmAuditer;
+    default:
+      throw new Error(`Invalid package manager: ${packageManager}`);
+  }
+}
+
 function audit(
   config: AuditCiConfig,
   reporter?: (summary: Summary, config: AuditCiConfig) => Summary
@@ -24,7 +38,7 @@ function audit(
     "package-manager": packageManager,
     "output-format": outputFormat,
   } = config;
-  const auditor = packageManager === "npm" ? npmAuditer : yarnAuditer;
+  const auditor = getAuditor(packageManager);
 
   async function run(attempt = 0) {
     try {

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -83,13 +83,9 @@ class Model {
 
     const allowlistedPathsFoundSet = new Set<string>();
 
-    const flattenedPaths: string[] = advisory.findings
-      .flatMap((finding) => finding.paths)
-      // PNPM paths have a leading `.>`
-      // "paths": [
-      //  ".>cryo"
-      //]
-      .map((path) => path.replace(".>", ""));
+    const flattenedPaths: string[] = advisory.findings.flatMap(
+      (finding) => finding.paths
+    );
     const flattenedAllowlist = flattenedPaths.map(
       (path: string) => `${advisory.github_advisory_id}|${path}`
     );
@@ -116,10 +112,21 @@ class Model {
 
     if (parsedOutput.advisories) {
       for (const advisory of Object.values(parsedOutput.advisories)) {
+        const advisoryAny = advisory as any;
         // eslint-disable-next-line no-param-reassign, prefer-destructuring
-        (advisory as any).github_advisory_id = gitHubAdvisoryUrlToAdvisoryId(
-          (advisory as any).url
+        advisoryAny.github_advisory_id = gitHubAdvisoryUrlToAdvisoryId(
+          advisoryAny.url
         );
+        // PNPM paths have a leading `.>`
+        // "paths": [
+        //  ".>module-name"
+        //]
+        for (const finding of advisoryAny.findings) {
+          const findingAny = finding as any;
+          findingAny.paths = findingAny.paths.map((path) =>
+            path.replace(".>", "")
+          );
+        }
         this.process(advisory);
       }
       return this.getSummary();

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -83,9 +83,13 @@ class Model {
 
     const allowlistedPathsFoundSet = new Set<string>();
 
-    const flattenedPaths: string[] = advisory.findings.flatMap(
-      (finding) => finding.paths
-    );
+    const flattenedPaths: string[] = advisory.findings
+      .flatMap((finding) => finding.paths)
+      // PNPM paths have a leading `.>`
+      // "paths": [
+      //  ".>cryo"
+      //]
+      .map((path) => path.replace(".>", ""));
     const flattenedAllowlist = flattenedPaths.map(
       (path: string) => `${advisory.github_advisory_id}|${path}`
     );
@@ -121,7 +125,7 @@ class Model {
       return this.getSummary();
     }
 
-    /** NPM 7+ */
+    /** NPM 7+ & PNPM */
 
     // This is incomplete. Rather than filling it out, plan on consuming an external dependency to manage.
     type NPM7Vulnerability = {

--- a/lib/pnpm-auditer.ts
+++ b/lib/pnpm-auditer.ts
@@ -1,0 +1,111 @@
+import { blue, yellow } from "./colors";
+import { reportAudit, runProgram } from "./common";
+import { AuditCiConfig } from "./config";
+import Model from "./model";
+
+async function runPnpmAudit(config: AuditCiConfig) {
+  const {
+    directory,
+    registry,
+    _pnpm,
+    "skip-dev": skipDevelopmentDependencies,
+  } = config;
+  const pnpmExec = _pnpm || "pnpm";
+
+  let stdoutBuffer: any = {};
+  function outListener(data: any) {
+    stdoutBuffer = { ...stdoutBuffer, ...data };
+  }
+
+  const stderrBuffer: any[] = [];
+  function errorListener(line: any) {
+    stderrBuffer.push(line);
+  }
+
+  const arguments_ = ["audit", "--json"];
+  if (registry) {
+    console.warn(yellow, "Yarn audit does not support the registry flag yet.");
+  }
+  if (skipDevelopmentDependencies) {
+    arguments_.push("--prod");
+  }
+  const options = { cwd: directory };
+  await runProgram(pnpmExec, arguments_, options, outListener, errorListener);
+  if (stderrBuffer.length > 0) {
+    throw new Error(
+      `Invocation of pnpm audit failed:\n${stderrBuffer.join("\n")}`
+    );
+  }
+  return stdoutBuffer;
+}
+
+function printReport(
+  parsedOutput: any,
+  levels: any,
+  reportType: "full" | "important" | "summary",
+  outputFormat: "text" | "json"
+) {
+  const printReportObject = (text, object) => {
+    if (outputFormat === "text") {
+      console.log(blue, text);
+    }
+    console.log(JSON.stringify(object, undefined, 2));
+  };
+  switch (reportType) {
+    case "full":
+      printReportObject("PNPM audit report JSON:", parsedOutput);
+      break;
+    case "important": {
+      const { advisories, metadata } = parsedOutput;
+
+      const relevantAdvisoryLevels = Object.keys(advisories).filter(
+        (advisory) => levels[advisories[advisory].severity]
+      );
+
+      const relevantAdvisories = {};
+      for (const advisory of relevantAdvisoryLevels) {
+        relevantAdvisories[advisory] = advisories[advisory];
+      }
+
+      const keyFindings = {
+        advisories: relevantAdvisories,
+        metadata: metadata,
+      };
+      printReportObject("PNPM audit report results:", keyFindings);
+      break;
+    }
+    case "summary":
+      printReportObject("PNPM audit report summary:", parsedOutput.metadata);
+      break;
+    default:
+      throw new Error(
+        `Invalid report type: ${reportType}. Should be \`['important', 'full', 'summary']\`.`
+      );
+  }
+}
+
+export function report(parsedOutput, config: AuditCiConfig, reporter) {
+  const {
+    levels,
+    "report-type": reportType,
+    "output-format": outputFormat,
+  } = config;
+  printReport(parsedOutput, levels, reportType, outputFormat);
+  const model = new Model(config);
+  const summary = model.load(parsedOutput);
+  return reporter(summary, config, parsedOutput);
+}
+
+/**
+ * Audit your PNPM project!
+ *
+ * @returns Returns the audit report summary on resolve, `Error` on rejection.
+ */
+export async function audit(config: AuditCiConfig, reporter = reportAudit) {
+  const parsedOutput = await runPnpmAudit(config);
+  if (parsedOutput.error) {
+    const { code, summary } = parsedOutput.error;
+    throw new Error(`code ${code}: ${summary}`);
+  }
+  return report(parsedOutput, config, reporter);
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audit-ci",
   "version": "6.0.0",
-  "description": "Audits npm and yarn projects in CI environments",
+  "description": "Audits NPM, Yarn, and PNPM projects in CI environments",
   "license": "Apache-2.0",
   "main": "./dist/audit-ci.js",
   "homepage": "https://github.com/IBM/audit-ci",
@@ -15,6 +15,7 @@
     "ci",
     "npm",
     "yarn",
+    "pnpm",
     "security",
     "github",
     "actions",

--- a/test/npm-auditer.spec.js
+++ b/test/npm-auditer.spec.js
@@ -1,7 +1,11 @@
 const { expect } = require("chai");
 const { audit, report } = require("../dist/npm-auditer");
 const { default: Allowlist } = require("../dist/allowlist");
-const { summaryWithDefault, config, testDirectory } = require("./common");
+const {
+  summaryWithDefault,
+  config: baseConfig,
+  testDirectory,
+} = require("./common");
 
 const reportNpmCritical = require("./npm-critical/npm-output.json");
 const reportNpmHighSeverity = require("./npm-high/npm-output.json");
@@ -10,6 +14,10 @@ const reportNpmAllowlistedPath = require("./npm-allowlisted-path/npm-output.json
 const reportNpmLow = require("./npm-low/npm-output.json");
 const reportNpmNone = require("./npm-none/npm-output.json");
 const reportNpmSkipDevelopment = require("./npm-skip-dev/npm-output.json");
+
+function config(additions) {
+  return baseConfig({ ...additions, "package-manager": "npm" });
+}
 
 // To modify what slow times are, need to use
 // function() {} instead of () => {}

--- a/test/pnpm-allowlisted-path/package.json
+++ b/test/pnpm-allowlisted-path/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "audit-ci-npm-allowlisted-path",
+  "dependencies": {
+    "axios": "^0.15.3",
+    "github-build": "^1.2.0"
+  }
+}

--- a/test/pnpm-allowlisted-path/pnpm-lock.yaml
+++ b/test/pnpm-allowlisted-path/pnpm-lock.yaml
@@ -1,0 +1,60 @@
+lockfileVersion: 5.3
+
+specifiers:
+  axios: ^0.15.3
+  github-build: ^1.2.0
+
+dependencies:
+  axios: 0.15.3
+  github-build: 1.2.3
+
+packages:
+
+  /axios/0.15.3:
+    resolution: {integrity: sha1-LJ1jiy4ZGgjqHWzJiOrda6W9wFM=}
+    deprecated: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
+    dependencies:
+      follow-redirects: 1.0.0
+    dev: false
+
+  /axios/0.21.3:
+    resolution: {integrity: sha512-JtoZ3Ndke/+Iwt5n+BgSli/3idTvpt5OjKyoCmz4LX5+lPiY5l7C1colYezhlxThjNa/NhngCUWZSZFypIFuaA==}
+    dependencies:
+      follow-redirects: 1.14.9
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /debug/2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    dependencies:
+      ms: 2.0.0
+    dev: false
+
+  /follow-redirects/1.0.0:
+    resolution: {integrity: sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=}
+    dependencies:
+      debug: 2.6.9
+    dev: false
+
+  /follow-redirects/1.14.9:
+    resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
+  /github-build/1.2.3:
+    resolution: {integrity: sha512-57zUA9ZbaKQHxoUATq3dkr+gUeaOWGGC/3Vw/AJNIUkiUmd7DnYM9TMTmUknbkuvx6+SeSqWpLBunZZzCPLUMg==}
+    dependencies:
+      axios: 0.21.3
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /ms/2.0.0:
+    resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
+    dev: false

--- a/test/pnpm-allowlisted-path/pnpm-output.json
+++ b/test/pnpm-allowlisted-path/pnpm-output.json
@@ -1,0 +1,263 @@
+{
+  "actions": [
+    {
+      "action": "review",
+      "module": "follow-redirects",
+      "resolves": [
+        {
+          "id": 1064611,
+          "path": ".>axios>follow-redirects",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1064664,
+          "path": ".>axios>follow-redirects",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ]
+    },
+    {
+      "action": "review",
+      "module": "axios",
+      "resolves": [
+        {
+          "id": 1064917,
+          "path": ".>axios",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1065494,
+          "path": ".>axios",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1066821,
+          "path": ".>axios",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ]
+    }
+  ],
+  "advisories": {
+    "1064611": {
+      "findings": [
+        {
+          "version": "1.0.0",
+          "paths": [
+            ".>axios>follow-redirects"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<1.14.8",
+      "module_name": "follow-redirects",
+      "severity": "moderate",
+      "github_advisory_id": "GHSA-pw2r-vq6v-hr8c",
+      "cves": [
+        "CVE-2022-0536"
+      ],
+      "access": "public",
+      "patched_versions": ">=1.14.8",
+      "cvss": {
+        "score": 5.9,
+        "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+      },
+      "updated": "2022-02-11T21:18:03.000Z",
+      "recommendation": "Upgrade to version 1.14.8 or later",
+      "cwe": [
+        "CWE-200"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1064611,
+      "references": "- https://nvd.nist.gov/vuln/detail/CVE-2022-0536\n- https://github.com/follow-redirects/follow-redirects/commit/62e546a99c07c3ee5e4e0718c84a6ca127c5c445\n- https://huntr.dev/bounties/7cf2bf90-52da-4d59-8028-a73b132de0db\n- https://github.com/advisories/GHSA-pw2r-vq6v-hr8c",
+      "created": "2022-03-11T08:00:43.754Z",
+      "reported_by": null,
+      "title": "Exposure of Sensitive Information to an Unauthorized Actor in follow-redirects",
+      "npm_advisory_id": null,
+      "overview": "Exposure of Sensitive Information to an Unauthorized Actor in NPM follow-redirects prior to 1.14.8.",
+      "url": "https://github.com/advisories/GHSA-pw2r-vq6v-hr8c"
+    },
+    "1064664": {
+      "findings": [
+        {
+          "version": "1.0.0",
+          "paths": [
+            ".>axios>follow-redirects"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<1.14.7",
+      "module_name": "follow-redirects",
+      "severity": "high",
+      "github_advisory_id": "GHSA-74fj-2j2h-c42q",
+      "cves": [
+        "CVE-2022-0155"
+      ],
+      "access": "public",
+      "patched_versions": ">=1.14.7",
+      "cvss": {
+        "score": 8,
+        "vectorString": "CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+      },
+      "updated": "2022-01-11T18:41:09.000Z",
+      "recommendation": "Upgrade to version 1.14.7 or later",
+      "cwe": [
+        "CWE-359"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1064664,
+      "references": "- https://nvd.nist.gov/vuln/detail/CVE-2022-0155\n- https://github.com/follow-redirects/follow-redirects/commit/8b347cbcef7c7b72a6e9be20f5710c17d6163c22\n- https://huntr.dev/bounties/fc524e4b-ebb6-427d-ab67-a64181020406\n- https://github.com/advisories/GHSA-74fj-2j2h-c42q",
+      "created": "2022-03-11T08:00:43.764Z",
+      "reported_by": null,
+      "title": "Exposure of sensitive information in follow-redirects",
+      "npm_advisory_id": null,
+      "overview": "follow-redirects is vulnerable to Exposure of Private Personal Information to an Unauthorized Actor",
+      "url": "https://github.com/advisories/GHSA-74fj-2j2h-c42q"
+    },
+    "1064917": {
+      "findings": [
+        {
+          "version": "0.15.3",
+          "paths": [
+            ".>axios"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<=0.21.1",
+      "module_name": "axios",
+      "severity": "high",
+      "github_advisory_id": "GHSA-cph5-m8f7-6c5x",
+      "cves": [
+        "CVE-2021-3749"
+      ],
+      "access": "public",
+      "patched_versions": ">=0.21.2",
+      "cvss": {
+        "score": 7.5,
+        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      },
+      "updated": "2021-09-08T16:46:47.000Z",
+      "recommendation": "Upgrade to version 0.21.2 or later",
+      "cwe": [
+        "CWE-697"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1064917,
+      "references": "- https://nvd.nist.gov/vuln/detail/CVE-2021-3749\n- https://github.com/axios/axios/commit/5b457116e31db0e88fede6c428e969e87f290929\n- https://huntr.dev/bounties/1e8f07fc-c384-4ff9-8498-0690de2e8c31\n- https://www.npmjs.com/package/axios\n- https://lists.apache.org/thread.html/r075d464dce95cd13c03ff9384658edcccd5ab2983b82bfc72b62bb10@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/r216f0fd0a3833856d6a6a1fada488cadba45f447d87010024328ccf2@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/r3ae6d2654f92c5851bdb73b35e96b0e4e3da39f28ac7a1b15ae3aab8@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/r4bf1b32983f50be00f9752214c1b53738b621be1c2b0dbd68c7f2391@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/r7324ecc35b8027a51cb6ed629490fcd3b2d7cf01c424746ed5744bf1@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/r74d0b359408fff31f87445261f0ee13bdfcac7d66f6b8e846face321@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/ra15d63c54dc6474b29f72ae4324bcb03038758545b3ab800845de7a1@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/rc263bfc5b53afcb7e849605478d73f5556eb0c00d1f912084e407289@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/rfa094029c959da0f7c8cd7dc9c4e59d21b03457bf0cedf6c93e1bb0a@%3Cdev.druid.apache.org%3E\n- https://lists.apache.org/thread.html/rfc5c478053ff808671aef170f3d9fc9d05cc1fab8fb64431edc66103@%3Ccommits.druid.apache.org%3E\n- https://github.com/advisories/GHSA-cph5-m8f7-6c5x",
+      "created": "2022-03-11T08:00:43.804Z",
+      "reported_by": null,
+      "title": "Incorrect Comparison in axios",
+      "npm_advisory_id": null,
+      "overview": "axios is vulnerable to Inefficient Regular Expression Complexity",
+      "url": "https://github.com/advisories/GHSA-cph5-m8f7-6c5x"
+    },
+    "1065494": {
+      "findings": [
+        {
+          "version": "0.15.3",
+          "paths": [
+            ".>axios"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<0.21.1",
+      "module_name": "axios",
+      "severity": "high",
+      "github_advisory_id": "GHSA-4w2v-q235-vp99",
+      "cves": [
+        "CVE-2020-28168"
+      ],
+      "access": "public",
+      "patched_versions": ">=0.21.1",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "updated": "2021-01-04T20:58:17.000Z",
+      "recommendation": "Upgrade to version 0.21.1 or later",
+      "cwe": [
+        "CWE-918"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1065494,
+      "references": "- https://nvd.nist.gov/vuln/detail/CVE-2020-28168\n- https://github.com/axios/axios/issues/3369\n- https://github.com/axios/axios/commit/c7329fefc890050edd51e40e469a154d0117fc55\n- https://snyk.io/vuln/SNYK-JS-AXIOS-1038255\n- https://www.npmjs.com/package/axios\n- https://www.npmjs.com/advisories/1594\n- https://lists.apache.org/thread.html/r954d80fd18e9dafef6e813963eb7e08c228151c2b6268ecd63b35d1f@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/r25d53acd06f29244b8a103781b0339c5e7efee9099a4d52f0c230e4a@%3Ccommits.druid.apache.org%3E\n- https://lists.apache.org/thread.html/rdfd2901b8b697a3f6e2c9c6ecc688fd90d7f881937affb5144d61d6e@%3Ccommits.druid.apache.org%3E\n- https://github.com/advisories/GHSA-4w2v-q235-vp99",
+      "created": "2022-03-11T08:00:43.845Z",
+      "reported_by": null,
+      "title": "Server-Side Request Forgery in Axios",
+      "npm_advisory_id": null,
+      "overview": "Axios NPM package 0.21.0 contains a Server-Side Request Forgery (SSRF) vulnerability where an attacker is able to bypass a proxy by providing a URL that responds with a redirect to a restricted host or IP address.",
+      "url": "https://github.com/advisories/GHSA-4w2v-q235-vp99"
+    },
+    "1066821": {
+      "findings": [
+        {
+          "version": "0.15.3",
+          "paths": [
+            ".>axios"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<=0.18.0",
+      "module_name": "axios",
+      "severity": "high",
+      "github_advisory_id": "GHSA-42xw-2xvc-qx8m",
+      "cves": [
+        "CVE-2019-10742"
+      ],
+      "access": "public",
+      "patched_versions": ">=0.18.1",
+      "cvss": {
+        "score": 7.5,
+        "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      },
+      "updated": "2019-06-05T16:22:11.000Z",
+      "recommendation": "Upgrade to version 0.18.1 or later",
+      "cwe": [
+        "CWE-20",
+        "CWE-755"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1066821,
+      "references": "- https://nvd.nist.gov/vuln/detail/CVE-2019-10742\n- https://app.snyk.io/vuln/SNYK-JS-AXIOS-174505\n- https://github.com/axios/axios/issues/1098\n- https://github.com/axios/axios/pull/1485\n- https://snyk.io/vuln/SNYK-JS-AXIOS-174505\n- https://www.npmjs.com/advisories/880\n- https://github.com/advisories/GHSA-42xw-2xvc-qx8m",
+      "created": "2022-03-11T08:00:43.925Z",
+      "reported_by": null,
+      "title": "Denial of Service in axios",
+      "npm_advisory_id": null,
+      "overview": "Versions of `axios` prior to 0.18.1 are vulnerable to Denial of Service. If a request exceeds the `maxContentLength` property, the package prints an error but does not stop the request. This may cause high CPU usage and lead to Denial of Service.\n\n\n## Recommendation\n\nUpgrade to 0.18.1 or later.",
+      "url": "https://github.com/advisories/GHSA-42xw-2xvc-qx8m"
+    }
+  },
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 1,
+      "high": 4,
+      "critical": 0
+    },
+    "dependencies": 8,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 8
+  }
+}

--- a/test/pnpm-config-file/audit-ci-with-comment.json
+++ b/test/pnpm-config-file/audit-ci-with-comment.json
@@ -1,0 +1,5 @@
+{
+  // JSON comment
+  "low": "true",
+  "allowlist": ["open"]
+}

--- a/test/pnpm-config-file/audit-ci-with-comment.json5
+++ b/test/pnpm-config-file/audit-ci-with-comment.json5
@@ -1,0 +1,8 @@
+{
+  // JSON comment
+  low: "true",
+  allowlist: [
+    /** JSON comment */
+    "open",
+  ],
+}

--- a/test/pnpm-config-file/audit-ci-with-comment.jsonc
+++ b/test/pnpm-config-file/audit-ci-with-comment.jsonc
@@ -1,0 +1,8 @@
+{
+  // JSON comment
+  "low": "true",
+  "allowlist": [
+    /** JSON comment */
+    "open"
+  ]
+}

--- a/test/pnpm-config-file/audit-ci.json
+++ b/test/pnpm-config-file/audit-ci.json
@@ -1,0 +1,4 @@
+{
+  "low": "true",
+  "allowlist": ["open"]
+}

--- a/test/pnpm-config-file/package.json
+++ b/test/pnpm-config-file/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "audit-ci-npm-config",
+  "description": "Test package.json with config file",
+  "dependencies": {
+    "open": "0.0.5"
+  }
+}

--- a/test/pnpm-config-file/pnpm-lock.yaml
+++ b/test/pnpm-config-file/pnpm-lock.yaml
@@ -1,0 +1,14 @@
+lockfileVersion: 5.3
+
+specifiers:
+  open: 0.0.5
+
+dependencies:
+  open: 0.0.5
+
+packages:
+
+  /open/0.0.5:
+    resolution: {integrity: sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=}
+    engines: {node: '>= 0.6.0'}
+    dev: false

--- a/test/pnpm-config-file/pnpm-output.json
+++ b/test/pnpm-config-file/pnpm-output.json
@@ -1,0 +1,70 @@
+{
+  "actions": [
+    {
+      "action": "review",
+      "module": "open",
+      "resolves": [
+        {
+          "id": 1066786,
+          "path": ".>open",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ]
+    }
+  ],
+  "advisories": {
+    "1066786": {
+      "findings": [
+        {
+          "version": "0.0.5",
+          "paths": [
+            ".>open"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<6.0.0",
+      "module_name": "open",
+      "severity": "critical",
+      "github_advisory_id": "GHSA-28xh-wpgr-7fm8",
+      "cves": [],
+      "access": "public",
+      "patched_versions": ">=6.0.0",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "updated": "2019-06-20T15:35:08.000Z",
+      "recommendation": "Upgrade to version 6.0.0 or later",
+      "cwe": [
+        "CWE-77"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1066786,
+      "references": "- https://github.com/pwnall/node-open/issues/68\n- https://github.com/pwnall/node-open/issues/69\n- https://hackerone.com/reports/319473\n- https://nodesecurity.io/advisories/663\n- https://www.npmjs.com/advisories/663\n- https://github.com/advisories/GHSA-28xh-wpgr-7fm8",
+      "created": "2022-03-11T08:00:43.923Z",
+      "reported_by": null,
+      "title": "Command Injection in open",
+      "npm_advisory_id": null,
+      "overview": "Versions of `open` before 6.0.0 are vulnerable to command injection when unsanitized user input is passed in.\n\nThe package does come with the following warning in the readme:\n\n```\nThe same care should be taken when calling open as if you were calling child_process.exec directly. If it is an executable it will run in a new shell.\n```\n\n\n## Recommendation\n\n`open` is now the deprecated `opn` package. Upgrading to the latest version is likely have unwanted effects since it now has a very different API but will prevent this vulnerability.",
+      "url": "https://github.com/advisories/GHSA-28xh-wpgr-7fm8"
+    }
+  },
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 1
+    },
+    "dependencies": 2,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 2
+  }
+}

--- a/test/pnpm-critical/package.json
+++ b/test/pnpm-critical/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "audit-ci-npm-critical-vulnerability",
+  "description": "Test package.json with critical vulnerability",
+  "dependencies": {
+    "open": "0.0.5"
+  }
+}

--- a/test/pnpm-critical/pnpm-lock.yaml
+++ b/test/pnpm-critical/pnpm-lock.yaml
@@ -1,0 +1,14 @@
+lockfileVersion: 5.3
+
+specifiers:
+  open: 0.0.5
+
+dependencies:
+  open: 0.0.5
+
+packages:
+
+  /open/0.0.5:
+    resolution: {integrity: sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=}
+    engines: {node: '>= 0.6.0'}
+    dev: false

--- a/test/pnpm-critical/pnpm-output.json
+++ b/test/pnpm-critical/pnpm-output.json
@@ -1,0 +1,70 @@
+{
+  "actions": [
+    {
+      "action": "review",
+      "module": "open",
+      "resolves": [
+        {
+          "id": 1066786,
+          "path": ".>open",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ]
+    }
+  ],
+  "advisories": {
+    "1066786": {
+      "findings": [
+        {
+          "version": "0.0.5",
+          "paths": [
+            ".>open"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<6.0.0",
+      "module_name": "open",
+      "severity": "critical",
+      "github_advisory_id": "GHSA-28xh-wpgr-7fm8",
+      "cves": [],
+      "access": "public",
+      "patched_versions": ">=6.0.0",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "updated": "2019-06-20T15:35:08.000Z",
+      "recommendation": "Upgrade to version 6.0.0 or later",
+      "cwe": [
+        "CWE-77"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1066786,
+      "references": "- https://github.com/pwnall/node-open/issues/68\n- https://github.com/pwnall/node-open/issues/69\n- https://hackerone.com/reports/319473\n- https://nodesecurity.io/advisories/663\n- https://www.npmjs.com/advisories/663\n- https://github.com/advisories/GHSA-28xh-wpgr-7fm8",
+      "created": "2022-03-11T08:00:43.923Z",
+      "reported_by": null,
+      "title": "Command Injection in open",
+      "npm_advisory_id": null,
+      "overview": "Versions of `open` before 6.0.0 are vulnerable to command injection when unsanitized user input is passed in.\n\nThe package does come with the following warning in the readme:\n\n```\nThe same care should be taken when calling open as if you were calling child_process.exec directly. If it is an executable it will run in a new shell.\n```\n\n\n## Recommendation\n\n`open` is now the deprecated `opn` package. Upgrading to the latest version is likely have unwanted effects since it now has a very different API but will prevent this vulnerability.",
+      "url": "https://github.com/advisories/GHSA-28xh-wpgr-7fm8"
+    }
+  },
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 1
+    },
+    "dependencies": 2,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 2
+  }
+}

--- a/test/pnpm-high/package.json
+++ b/test/pnpm-high/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "audit-ci-npm-high-vulnerability",
+  "description": "Test package.json with high vulnerability",
+  "dependencies": {
+    "cryo": "0.0.6"
+  }
+}

--- a/test/pnpm-high/pnpm-lock.yaml
+++ b/test/pnpm-high/pnpm-lock.yaml
@@ -1,0 +1,14 @@
+lockfileVersion: 5.3
+
+specifiers:
+  cryo: 0.0.6
+
+dependencies:
+  cryo: 0.0.6
+
+packages:
+
+  /cryo/0.0.6:
+    resolution: {integrity: sha1-FoMyldLuFv85cR24QGF7euSvC6Q=}
+    engines: {node: '>= 0.4.x'}
+    dev: false

--- a/test/pnpm-high/pnpm-output.json
+++ b/test/pnpm-high/pnpm-output.json
@@ -1,0 +1,72 @@
+{
+  "actions": [
+    {
+      "action": "review",
+      "module": "cryo",
+      "resolves": [
+        {
+          "id": 1066151,
+          "path": ".>cryo",
+          "dev": false,
+          "bundled": false,
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "advisories": {
+    "1066151": {
+      "findings": [
+        {
+          "version": "0.0.6",
+          "paths": [
+            ".>cryo"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<=0.0.6",
+      "module_name": "cryo",
+      "severity": "high",
+      "github_advisory_id": "GHSA-38f5-ghc2-fcmv",
+      "cves": [
+        "CVE-2018-3784"
+      ],
+      "access": "public",
+      "patched_versions": "<0.0.0",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "updated": "2020-08-31T18:32:59.000Z",
+      "recommendation": "None",
+      "cwe": [
+        "CWE-94"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1066151,
+      "references": "- https://nvd.nist.gov/vuln/detail/CVE-2018-3784\n- https://hackerone.com/reports/350418\n- https://github.com/advisories/GHSA-38f5-ghc2-fcmv\n- https://www.npmjs.com/advisories/690",
+      "created": "2022-03-11T08:00:43.889Z",
+      "reported_by": null,
+      "title": "Code Injection in cryo",
+      "npm_advisory_id": null,
+      "overview": "All versions of `cryo` are vulnerable to code injection due to an Insecure implementation of deserialization.\n\n\n## Proof of concept\n\n```\nvar Cryo = require('cryo');\nvar frozen = '{\"root\":\"_CRYO_REF_3\",\"references\":[{\"contents\":{},\"value\":\"_CRYO_FUNCTION_function () {console.log(\\\\\"defconrussia\\\\\"); return 1111;}\"},{\"contents\":{},\"value\":\"_CRYO_FUNCTION_function () {console.log(\\\\\"defconrussia\\\\\");return 2222;}\"},{\"contents\":{\"toString\":\"_CRYO_REF_0\",\"valueOf\":\"_CRYO_REF_1\"},\"value\":\"_CRYO_OBJECT_\"},{\"contents\":{\"__proto__\":\"_CRYO_REF_2\"},\"value\":\"_CRYO_OBJECT_\"}]}'\nvar hydrated = Cryo.parse(frozen);\nconsole.log(hydrated);\n```\n\n\n## Recommendation\n\nNo fix is currently available. Consider using an alternative module until a fix is made available.",
+      "url": "https://github.com/advisories/GHSA-38f5-ghc2-fcmv"
+    }
+  },
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 1,
+      "critical": 0
+    },
+    "dependencies": 2,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 2
+  }
+}

--- a/test/pnpm-low/package.json
+++ b/test/pnpm-low/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "audit-ci-npm-low-vulnerability",
+  "description": "Test package.json with low vulnerability",
+  "dependencies": {
+    "chownr": "1.0.0"
+  }
+}

--- a/test/pnpm-low/pnpm-lock.yaml
+++ b/test/pnpm-low/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+lockfileVersion: 5.3
+
+specifiers:
+  chownr: 1.0.0
+
+dependencies:
+  chownr: 1.0.0
+
+packages:
+
+  /chownr/1.0.0:
+    resolution: {integrity: sha1-AoVYM9IFFc8mgccX1oa7jB8+qRo=}
+    dev: false

--- a/test/pnpm-low/pnpm-output.json
+++ b/test/pnpm-low/pnpm-output.json
@@ -1,0 +1,72 @@
+{
+  "actions": [
+    {
+      "action": "review",
+      "module": "chownr",
+      "resolves": [
+        {
+          "id": 1065151,
+          "path": ".>chownr",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ]
+    }
+  ],
+  "advisories": {
+    "1065151": {
+      "findings": [
+        {
+          "version": "1.0.0",
+          "paths": [
+            ".>chownr"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<1.1.0",
+      "module_name": "chownr",
+      "severity": "low",
+      "github_advisory_id": "GHSA-c6rq-rjc2-86v2",
+      "cves": [
+        "CVE-2017-18869"
+      ],
+      "access": "public",
+      "patched_versions": ">=1.1.0",
+      "cvss": {
+        "score": 2.5,
+        "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:N"
+      },
+      "updated": "2021-05-12T20:23:30.000Z",
+      "recommendation": "Upgrade to version 1.1.0 or later",
+      "cwe": [
+        "CWE-367"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1065151,
+      "references": "- https://nvd.nist.gov/vuln/detail/CVE-2017-18869\n- https://github.com/isaacs/chownr/issues/14\n- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863985\n- https://bugzilla.redhat.com/show_bug.cgi?id=1611614\n- https://snyk.io/vuln/npm:chownr:20180731\n- https://github.com/advisories/GHSA-c6rq-rjc2-86v2",
+      "created": "2022-03-11T08:00:43.827Z",
+      "reported_by": null,
+      "title": "Time-of-check Time-of-use (TOCTOU) Race Condition in chownr",
+      "npm_advisory_id": null,
+      "overview": "A TOCTOU issue in the chownr package before 1.1.0 for Node.js 10.10 could allow a local attacker to trick it into descending into unintended directories via symlink attacks.",
+      "url": "https://github.com/advisories/GHSA-c6rq-rjc2-86v2"
+    }
+  },
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 1,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0
+    },
+    "dependencies": 2,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 2
+  }
+}

--- a/test/pnpm-moderate/package.json
+++ b/test/pnpm-moderate/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "audit-ci-npm-moderate-vulnerability",
+  "description": "Test package.json with moderate vulnerability",
+  "dependencies": {
+    "base64url": "2.0.0"
+  }
+}

--- a/test/pnpm-moderate/pnpm-lock.yaml
+++ b/test/pnpm-moderate/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+lockfileVersion: 5.3
+
+specifiers:
+  base64url: 2.0.0
+
+dependencies:
+  base64url: 2.0.0
+
+packages:
+
+  /base64url/2.0.0:
+    resolution: {integrity: sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=}
+    dev: false

--- a/test/pnpm-moderate/pnpm-output.json
+++ b/test/pnpm-moderate/pnpm-output.json
@@ -1,0 +1,70 @@
+{
+  "actions": [
+    {
+      "action": "review",
+      "module": "base64url",
+      "resolves": [
+        {
+          "id": 1066169,
+          "path": ".>base64url",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ]
+    }
+  ],
+  "advisories": {
+    "1066169": {
+      "findings": [
+        {
+          "version": "2.0.0",
+          "paths": [
+            ".>base64url"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<3.0.0",
+      "module_name": "base64url",
+      "severity": "moderate",
+      "github_advisory_id": "GHSA-rvg8-pwq2-xj7q",
+      "cves": [],
+      "access": "public",
+      "patched_versions": ">=3.0.0",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "updated": "2020-08-31T18:31:39.000Z",
+      "recommendation": "Upgrade to version 3.0.0 or later",
+      "cwe": [
+        "CWE-125"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1066169,
+      "references": "- https://hackerone.com/reports/321687\n- https://www.npmjs.com/advisories/658\n- https://github.com/brianloveswords/base64url/pull/25\n- https://github.com/advisories/GHSA-rvg8-pwq2-xj7q",
+      "created": "2022-03-11T08:00:43.890Z",
+      "reported_by": null,
+      "title": "Out-of-bounds Read in base64url",
+      "npm_advisory_id": null,
+      "overview": "Versions of `base64url` before 3.0.0 are vulnerable to to out-of-bounds reads as it allocates uninitialized Buffers when number is passed in input on Node.js 4.x and below.\n\n\n## Recommendation\n\nUpdate to version 3.0.0 or later.",
+      "url": "https://github.com/advisories/GHSA-rvg8-pwq2-xj7q"
+    }
+  },
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 1,
+      "high": 0,
+      "critical": 0
+    },
+    "dependencies": 2,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 2
+  }
+}

--- a/test/pnpm-none/package.json
+++ b/test/pnpm-none/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "audit-ci-npm-no-vulnerability",
+  "description": "Test package.json with low vulnerability",
+  "dependencies": {
+    "node-noop": "1.0.0"
+  }
+}

--- a/test/pnpm-none/pnpm-lock.yaml
+++ b/test/pnpm-none/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+lockfileVersion: 5.3
+
+specifiers:
+  node-noop: 1.0.0
+
+dependencies:
+  node-noop: 1.0.0
+
+packages:
+
+  /node-noop/1.0.0:
+    resolution: {integrity: sha1-R6Pn2Az/qmRYNkvSLthcqzMHvnk=}
+    dev: false

--- a/test/pnpm-none/pnpm-output.json
+++ b/test/pnpm-none/pnpm-output.json
@@ -1,0 +1,18 @@
+{
+  "actions": [],
+  "advisories": {},
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0
+    },
+    "dependencies": 2,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 2
+  }
+}

--- a/test/pnpm-skip-dev/package.json
+++ b/test/pnpm-skip-dev/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "audit-ci-npm-skip-dev",
+  "description": "Test package.json with critical vulnerability in devDependencies",
+  "dependencies": {
+    "node-noop": "1.0.0"
+  },
+  "devDependencies": {
+    "open": "0.0.5"
+  }
+}

--- a/test/pnpm-skip-dev/pnpm-lock.yaml
+++ b/test/pnpm-skip-dev/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: 5.3
+
+specifiers:
+  node-noop: 1.0.0
+  open: 0.0.5
+
+dependencies:
+  node-noop: 1.0.0
+
+devDependencies:
+  open: 0.0.5
+
+packages:
+
+  /node-noop/1.0.0:
+    resolution: {integrity: sha1-R6Pn2Az/qmRYNkvSLthcqzMHvnk=}
+    dev: false
+
+  /open/0.0.5:
+    resolution: {integrity: sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=}
+    engines: {node: '>= 0.6.0'}
+    dev: true

--- a/test/pnpm-skip-dev/pnpm-output.json
+++ b/test/pnpm-skip-dev/pnpm-output.json
@@ -1,0 +1,70 @@
+{
+  "actions": [
+    {
+      "action": "review",
+      "module": "open",
+      "resolves": [
+        {
+          "id": 1066786,
+          "path": ".>open",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ]
+    }
+  ],
+  "advisories": {
+    "1066786": {
+      "findings": [
+        {
+          "version": "0.0.5",
+          "paths": [
+            ".>open"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<6.0.0",
+      "module_name": "open",
+      "severity": "critical",
+      "github_advisory_id": "GHSA-28xh-wpgr-7fm8",
+      "cves": [],
+      "access": "public",
+      "patched_versions": ">=6.0.0",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "updated": "2019-06-20T15:35:08.000Z",
+      "recommendation": "Upgrade to version 6.0.0 or later",
+      "cwe": [
+        "CWE-77"
+      ],
+      "found_by": null,
+      "deleted": null,
+      "id": 1066786,
+      "references": "- https://github.com/pwnall/node-open/issues/68\n- https://github.com/pwnall/node-open/issues/69\n- https://hackerone.com/reports/319473\n- https://nodesecurity.io/advisories/663\n- https://www.npmjs.com/advisories/663\n- https://github.com/advisories/GHSA-28xh-wpgr-7fm8",
+      "created": "2022-03-11T08:00:43.923Z",
+      "reported_by": null,
+      "title": "Command Injection in open",
+      "npm_advisory_id": null,
+      "overview": "Versions of `open` before 6.0.0 are vulnerable to command injection when unsanitized user input is passed in.\n\nThe package does come with the following warning in the readme:\n\n```\nThe same care should be taken when calling open as if you were calling child_process.exec directly. If it is an executable it will run in a new shell.\n```\n\n\n## Recommendation\n\n`open` is now the deprecated `opn` package. Upgrading to the latest version is likely have unwanted effects since it now has a very different API but will prevent this vulnerability.",
+      "url": "https://github.com/advisories/GHSA-28xh-wpgr-7fm8"
+    }
+  },
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 1
+    },
+    "dependencies": 3,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 3
+  }
+}

--- a/test/yarn-auditer.spec.js
+++ b/test/yarn-auditer.spec.js
@@ -22,6 +22,7 @@ function config(additions) {
     registry: undefined,
     "pass-enoaudit": false,
     "skip-dev": false,
+    "package-manager": "yarn",
   };
   return { ...defaultConfig, ...additions };
 }


### PR DESCRIPTION
Adds PNPM support.

The dependency resolution is similar to NPM 6 but it doesn't result in the same transitive pathings.

If you have dependencies:

A -> B -> C, where B and C have advisories and you depend directly on A and B but C transitively, A will not be in the audit report despite it being in the chain of paths. For NPM and Yarn, A will be in the paths.

Closes https://github.com/IBM/audit-ci/issues/194