### PR TITLE
fix: Handle unhandled promise rejections in bin

### DIFF
--- a/lib/bin.ts
+++ b/lib/bin.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
 import { runAuditCi } from "./audit-ci";
 
-runAuditCi();
+runAuditCi().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
When using Node 12/14 + allowlisting using the old advisory format, the pipeline unexpectedly passes because Node 12/14 does not throw an error with unhandled promise rejections.

Now, instead, we handle promise rejections at the root and explicitly `process.exit(1)`.

I found this out by looking at a community project:

https://github.com/brave-intl/publishers/runs/6428625498?check_suite_focus=true

This is the before-and-after of the change:
<img width="996" alt="image" src="https://user-images.githubusercontent.com/12538019/168684627-bebbd72f-dd57-4b2e-9aab-c8bdeeaedf01.png">

I am considering releasing this with a patch version bump.