### PR TITLE
chore: Remove can't find package.json warning.

### DIFF
--- a/lib/audit-ci-version.ts
+++ b/lib/audit-ci-version.ts
@@ -1,17 +1,9 @@
 import type { AuditCiConfig } from "./config";
 // Ignoring importing package.json because that changes the package's build
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { bugs, version } = require("../package.json");
-import { yellow } from "./colors";
+const { version } = require("../package.json");
 
 export const auditCiVersion = version as string;
-
-if (!auditCiVersion) {
-  console.log(
-    yellow,
-    `Could not identify audit-ci version. Please report this issue to ${bugs}.`
-  );
-}
 
 export function printAuditCiVersion(
   outputFormat?: AuditCiConfig["output-format"]


### PR DESCRIPTION
We've never received a report for this.