### PR TITLE
feat: Add support for importing audit-ci

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,15 @@
+export { default as Allowlist } from "./allowlist";
+export { runAuditCi } from "./audit-ci";
+export {
+  gitHubAdvisoryIdToUrl,
+  gitHubAdvisoryUrlToAdvisoryId,
+  isGitHubAdvisoryId,
+} from "./common";
+export { AuditCiConfig, AuditCiPreprocessedConfig } from "./config";
+export {
+  mapVulnerabilityLevelInput,
+  VulnerabilityLevels,
+} from "./map-vulnerability";
+export { audit as npmAudit } from "./npm-auditer";
+export { audit as pnpmAudit } from "./pnpm-auditer";
+export { audit as yarnAudit } from "./yarn-auditer";

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "6.2.1",
   "description": "Audits NPM, Yarn, and PNPM projects in CI environments",
   "license": "Apache-2.0",
-  "main": "./dist/audit-ci.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "homepage": "https://github.com/IBM/audit-ci",
   "bugs": "https://github.com/IBM/audit-ci/issues",
   "repository": {


### PR DESCRIPTION
Now, you can interact with audit-ci using code! I haven't written the documentation for this yet.
Also, since this is the first release of programmatic usage, the API is not expected to stay stable.
This current API is mostly for early adopters and to get quick feedback.

Note, I started exporting types in this PR: #270
Closes #212 (but should create a new ticket to document the API)