### PR TITLE
feat: implement allowlist records

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,53 @@ Wildcard matching works by:
 
 An allowlist record may include any number of wildcards such as `*|react-scripts>*>*>example>*`.
 
+#### Allowlist Formats
+
+The simplest way to add an advisory to the allowlist is using a string:
+
+```jsonc
+"allowlist": [
+  "axios"
+]
+```
+
+You can also use an object notation ([NSPRecord](#nsprecord-fields)) in which you can add notes and control the expiration of this exception:
+
+```jsonc
+"allowlist": [
+  {
+    "axios": {
+      "active": true,
+      "notes": "Ignore this until November 20th",
+      "expiry": "20 November 2022 11:00"
+    }
+  }
+]
+```
+
+`allowlist` supports both formats at the same time, so feel free to mix and match:
+
+```jsonc
+"allowlist": [
+  {
+    "axios": {
+      "active": true,
+      "notes": "Ignore this until November 20th",
+      "expiry": "20 November 2022 11:00"
+    }
+  },
+  "base64url"
+]
+```
+
+#### NSPRecord Fields
+
+| Attribute | Type             | Description                                               | Example                                                                                                                                                                                                                                                                                                                      |
+| --------- | ---------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `active`  | boolean          | Whether the exception is active or not                    | `true`                                                                                                                                                                                                                                                                                                                       |
+| `expiry`  | string \| number | Human-readable date, or milliseconds since the UNIX Epoch | - `'2020-01-31'` <br> - `'2020/01/31'` <br> - `'01/31/2021, 11:03:58'` <br> - `'1 March 2016 15:00'` <br> - `'1 March 2016 3:00 pm'` <br> - `'2012-01-26T13:51:50.417-07:00'` <br> - `'Sun, 11 Jul 2021 03:03:13 GMT'` <br> - `'Thu Jan 26 2017 11:00:00 GMT+1100 (Australian Eastern Daylight Time)'` <br> - `327611110417` |
+| `notes`   | string           | Notes related to the vulnerability.                       |
+
 ### GitHub Actions
 
 ```yml
@@ -237,7 +284,7 @@ A config file can manage auditing preferences for `audit-ci`. The config file's 
   "moderate": <boolean>, // [Optional] defaults `false`
   "high": <boolean>, // [Optional] defaults `false`
   "critical": <boolean>, // [Optional] defaults `false`
-  "allowlist": <string[]>, // [Optional] default `[]`
+  "allowlist": <(string | [NSPRecord](#nsprecord-fields))[]>, // [Optional] default `[]`
   "report-type": <string>, // [Optional] defaults `important`
   "package-manager": <string>, // [Optional] defaults `"auto"`
   "output-format": <string>, // [Optional] defaults `"text"`

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -3,10 +3,10 @@ import { parse } from "jju";
 // eslint-disable-next-line unicorn/import-style
 import * as path from "path";
 import { config } from "yargs";
-import Allowlist from "./allowlist";
+import Allowlist, { type AllowlistRecord } from "./allowlist";
 import {
   mapVulnerabilityLevelInput,
-  VulnerabilityLevels,
+  type VulnerabilityLevels,
 } from "./map-vulnerability";
 
 function mapReportTypeInput(
@@ -55,7 +55,7 @@ export type AuditCiPreprocessedConfig = {
   /** Package manager */
   "package-manager": "auto" | "npm" | "yarn" | "pnpm";
   a: string[];
-  allowlist: string[];
+  allowlist: AllowlistRecord[];
   /** The directory containing the package.json to audit */
   d: string;
   /** The directory containing the package.json to audit */

--- a/lib/nsp-record.ts
+++ b/lib/nsp-record.ts
@@ -1,0 +1,62 @@
+import type { GitHubAdvisoryId } from "audit-types";
+
+export interface NSPContent {
+  readonly active?: boolean;
+  readonly notes?: string;
+  readonly expiry?: string | number;
+}
+
+export type NSPRecord = Record<string, NSPContent>;
+export type GitHubNSPRecord = Record<GitHubAdvisoryId, NSPContent>;
+
+/**
+ * Retrieves the allowlist id from the NSPRecord.
+ *
+ * @param nspRecord NSPRecord object.
+ * @returns The advisory id.
+ */
+export function getAllowlistId(nspRecord: NSPRecord | GitHubNSPRecord): string {
+  return Object.keys(nspRecord)[0];
+}
+
+/**
+ * Retrieves the content for the NSPRecord.
+ *
+ * @param nspRecord NSPRecord object.
+ * @returns The NSPContent object.
+ */
+export function getNSPContent(
+  nspRecord: NSPRecord | GitHubNSPRecord
+): NSPContent {
+  return Object.values(nspRecord)[0];
+}
+
+/**
+ * Determines if the NSPRecord is active.
+ *
+ * @param nspRecord NSPRecord object.
+ * @param now The current date. The default is initialized to the current date.
+ * @returns True if the record is active, false otherwise.
+ */
+export function isNSPRecordActive(
+  nspRecord: NSPRecord,
+  now = new Date()
+): boolean {
+  const content = getNSPContent(nspRecord);
+  if (!content.active) {
+    return false;
+  }
+
+  if (content.expiry) {
+    const expiryDate = new Date(content.expiry);
+    if (expiryDate.getTime() > 0) {
+      // Expiry is valid, check if we've passed it yet.
+      return now.getTime() < expiryDate.getTime();
+    }
+
+    // Expiry isn't valid. For safety, disable the rule.
+    return false;
+  }
+
+  return true;
+}

--- a/test/npm7-auditer.spec.js
+++ b/test/npm7-auditer.spec.js
@@ -113,6 +113,28 @@ describe("npm7-auditer", () => {
       })
     );
   });
+  it("ignores an advisory if it is allowlisted using a NSPRecord", () => {
+    const summary = report(
+      reportNpmModerateSeverity,
+      config({
+        directory: testDirectory("npm-moderate"),
+        levels: { moderate: true },
+        allowlist: new Allowlist([
+          {
+            "GHSA-rvg8-pwq2-xj7q": {
+              active: true,
+            },
+          },
+        ]),
+      }),
+      (_summary) => _summary
+    );
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedAdvisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
+      })
+    );
+  });
   it("does not ignore an advisory that is not allowlisted", () => {
     const summary = report(
       reportNpmModerateSeverity,
@@ -120,6 +142,82 @@ describe("npm7-auditer", () => {
         directory: testDirectory("npm-moderate"),
         levels: { moderate: true },
         allowlist: new Allowlist(["GHSA-cff4-rrq6-h78w"]),
+      }),
+      (_summary) => _summary
+    );
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedAdvisoriesNotFound: ["GHSA-cff4-rrq6-h78w"],
+        failedLevelsFound: ["moderate"],
+        advisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
+        advisoryPathsFound: ["GHSA-rvg8-pwq2-xj7q|base64url"],
+      })
+    );
+  });
+  it("does not ignore an advisory that is not allowlisted using a NSPRecord", () => {
+    const summary = report(
+      reportNpmModerateSeverity,
+      config({
+        directory: testDirectory("npm-moderate"),
+        levels: { moderate: true },
+        allowlist: new Allowlist([
+          "GHSA-cff4-rrq6-h78w",
+          {
+            "GHSA-rvg8-pwq2-xj7q": {
+              active: false,
+            },
+          },
+        ]),
+      }),
+      (_summary) => _summary
+    );
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedAdvisoriesNotFound: ["GHSA-cff4-rrq6-h78w"],
+        failedLevelsFound: ["moderate"],
+        advisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
+        advisoryPathsFound: ["GHSA-rvg8-pwq2-xj7q|base64url"],
+      })
+    );
+  });
+  it("ignores an advisory that has not expired", () => {
+    const summary = report(
+      reportNpmModerateSeverity,
+      config({
+        directory: testDirectory("npm-moderate"),
+        levels: { moderate: true },
+        allowlist: new Allowlist([
+          {
+            "GHSA-rvg8-pwq2-xj7q": {
+              active: true,
+              expiry: new Date(Date.now() + 9000).toISOString(),
+            },
+          },
+        ]),
+      }),
+      (_summary) => _summary
+    );
+    expect(summary).to.eql(
+      summaryWithDefault({
+        allowlistedAdvisoriesFound: ["GHSA-rvg8-pwq2-xj7q"],
+      })
+    );
+  });
+  it("does not ignore an advisory that has expired", () => {
+    const summary = report(
+      reportNpmModerateSeverity,
+      config({
+        directory: testDirectory("npm-moderate"),
+        levels: { moderate: true },
+        allowlist: new Allowlist([
+          "GHSA-cff4-rrq6-h78w",
+          {
+            "GHSA-rvg8-pwq2-xj7q": {
+              active: true,
+              expiry: new Date(Date.now() - 9000).toISOString(),
+            },
+          },
+        ]),
       }),
       (_summary) => _summary
     );

--- a/test/nsp-record.spec.js
+++ b/test/nsp-record.spec.js
@@ -1,0 +1,154 @@
+const { expect } = require("chai");
+const {
+  getAllowlistId,
+  getNSPContent,
+  isNSPRecordActive,
+} = require("../dist/nsp-record");
+
+describe("getAllowlistId", () => {
+  it("should get the allowlist id", () => {
+    const id = getAllowlistId({
+      myid: {
+        active: true,
+      },
+    });
+    expect(id).to.eql("myid");
+  });
+});
+
+describe("getNSPContent", () => {
+  it("should get the content", () => {
+    const content = getNSPContent({
+      myid: {
+        active: true,
+        notes: "my notes",
+      },
+    });
+
+    expect(content).to.eql({
+      active: true,
+      notes: "my notes",
+    });
+  });
+});
+
+describe("isNSPRecordActive", () => {
+  const now = new Date("November 15, 2022 11:00:00");
+
+  it("should be active if active=true", () => {
+    const active = isNSPRecordActive({
+      myid: {
+        active: true,
+      },
+    });
+
+    expect(active).to.eql(true);
+  });
+
+  it("should not be active if active=false and there is no expiry", () => {
+    const active = isNSPRecordActive({
+      myid: {
+        active: false,
+      },
+    });
+
+    expect(active).to.eql(false);
+  });
+
+  it("should be active if expiry is in the future", () => {
+    const active = isNSPRecordActive(
+      {
+        myid: {
+          active: true,
+          expiry: "November 20, 2022 11:00:00",
+        },
+      },
+      now
+    );
+
+    expect(active).to.eql(true);
+  });
+
+  it("should not be active if expiry is in the past", () => {
+    const active = isNSPRecordActive(
+      {
+        myid: {
+          active: true,
+          expiry: "November 10, 2022 11:00:00",
+        },
+      },
+      now
+    );
+
+    expect(active).to.eql(false);
+  });
+
+  it("should not be active if expiry date is invalid", () => {
+    const active = isNSPRecordActive(
+      {
+        myid: {
+          active: true,
+          expiry: "INVALID",
+        },
+      },
+      now
+    );
+
+    expect(active).to.eql(false);
+  });
+
+  it("should test some different date formats", () => {
+    // These are variations of Nov 20, 2022.
+    const activeDates = [
+      "2022-11-20",
+      "2022/11/20",
+      "11/20/2022, 11:00:00",
+      "20 November 2022 11:00",
+      "20 November 2022 11:00 am",
+      "2022-11-20T11:00:00.000-08:00",
+      "Sun, 20 Nov 2022 11:00:00 PST",
+      // eslint-disable-next-line unicorn/numeric-separators-style
+      1668970800000,
+    ];
+    // These are variations of Nov 10, 2022.
+    const expiredDates = [
+      "2022-11-10",
+      "2022/11/10",
+      "11/10/2022, 11:00:00",
+      "10 November 2022 11:00",
+      "10 November 2022 11:00 am",
+      "2022-11-10T11:00:00.000-08:00",
+      "Thu, 10 Nov 2022 11:00:00 PST",
+      // eslint-disable-next-line unicorn/numeric-separators-style
+      1668106800000,
+    ];
+
+    for (const expiry of activeDates) {
+      expect(
+        isNSPRecordActive(
+          {
+            myid: {
+              active: true,
+              expiry,
+            },
+          },
+          now
+        )
+      ).to.eql(true);
+    }
+
+    for (const expiry of expiredDates) {
+      expect(
+        isNSPRecordActive(
+          {
+            myid: {
+              active: true,
+              expiry,
+            },
+          },
+          now
+        )
+      ).to.eql(false);
+    }
+  });
+});


### PR DESCRIPTION
Closes #277
Closes #278

Finishes the implementation from #279

@quinnturner I've integrated your code and made some changes so that it wouldn't be considered a breaking change to users who consume the API.  Inside the `Allowlist` class I stored the `NSPRecord`s under different fields.  Ultimately, string ids are still used around the library, so pre-processing them and storing them still sounded like a good idea. The `NSPRecord` fields aren't currently used, but they are stored in case API users need them.

Let me know if that approach works.

For now I've only added unit tests for the smaller functions in the implementation.  If the approach above looks good, I'll add additional tests for the full audit.