### PR TITLE
fix: fix types export in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "homepage": "https://github.com/IBM/audit-ci",


### PR DESCRIPTION
Move the `types` declaration in the `exports` field to the top.  According to the TS docs, the `types` field needs to come first.

https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

> The "types" condition should always come first in "exports".